### PR TITLE
[CH12120] Change Method to POST

### DIFF
--- a/library/src/main/java/io/constructor/core/Constants.kt
+++ b/library/src/main/java/io/constructor/core/Constants.kt
@@ -35,6 +35,10 @@ class Constants {
         const val FILTER_GROUP_ID = "filters[group_id]"
         const val FILTER_FACET = "filters[%s]"
         const val RESULT_ID = "result_id"
+        const val FILTER_NAME = "filter_name"
+        const val FILTER_VALUE = "filter_value"
+        const val RESULT_POSITION_ON_PAGE = "result_position_on_page"
+        const val RESULT_COUNT = "result_count"
     }
 
     object QueryValues {

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -355,7 +355,7 @@ object ConstructorIo {
             t -> e("Browse Results Loaded error: ${t.message}")
         }))
     }
-    internal fun trackBrowseResultsLoadedInternal(filterName: String?, filterValue: String?, resultCount: Int?): Completable {
+    internal fun trackBrowseResultsLoadedInternal(filterName: String, filterValue: String, resultCount: Int): Completable {
         preferenceHelper.getSessionId(sessionIncrementHandler)
         val browseResultLoadRequestBody = BrowseResultLoadRequestBody(
                 filterName,
@@ -364,12 +364,12 @@ object ConstructorIo {
                 BuildConfig.CLIENT_VERSION,
                 preferenceHelper.id,
                 preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
                 configMemoryHolder.userId,
                 configMemoryHolder.segments,
-                preferenceHelper.apiKey,
                 true,
                 preferenceHelper.defaultItemSection,
-                System.currentTimeMillis().toInt()
+                System.currentTimeMillis().toString()
         )
 
         return dataManager.trackBrowseResultsLoaded(
@@ -398,7 +398,7 @@ object ConstructorIo {
         preferenceHelper.getSessionId(sessionIncrementHandler)
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         resultID?.let { encodedParams.add(Constants.QueryConstants.RESULT_ID.urlEncode() to it.urlEncode()) }
-        val sName = sectionName ?: preferenceHelper.defaultItemSection
+        val section = sectionName ?: preferenceHelper.defaultItemSection
         val browseResultClickRequestBody = BrowseResultClickRequestBody(
                 filterName,
                 filterValue,
@@ -407,18 +407,18 @@ object ConstructorIo {
                 BuildConfig.CLIENT_VERSION,
                 preferenceHelper.id,
                 preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
                 configMemoryHolder.userId,
                 configMemoryHolder.segments,
-                preferenceHelper.apiKey,
                 true,
-                sName,
-                System.currentTimeMillis().toInt()
+                section,
+                System.currentTimeMillis().toString()
         )
 
         return dataManager.trackBrowseResultClick(
                 browseResultClickRequestBody,
                 arrayOf(
-                        Constants.QueryConstants.AUTOCOMPLETE_SECTION to sName
+                        Constants.QueryConstants.AUTOCOMPLETE_SECTION to section
                 ), encodedParams.toTypedArray()
         )
 

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -2,6 +2,7 @@ package io.constructor.core
 
 import android.annotation.SuppressLint
 import android.content.Context
+import io.constructor.BuildConfig
 import io.constructor.data.ConstructorData
 import io.constructor.data.DataManager
 import io.constructor.data.local.PreferencesHelper
@@ -352,11 +353,26 @@ object ConstructorIo {
             t -> e("Browse Results Loaded error: ${t.message}")
         }))
     }
-    internal fun trackBrowseResultsLoadedInternal(filterName: String, filterValue: String, resultCount: Int): Completable {
+    internal fun trackBrowseResultsLoadedInternal(filterName: String?, filterValue: String?, resultCount: Int?): Completable {
         preferenceHelper.getSessionId(sessionIncrementHandler)
-        return dataManager.trackBrowseResultsLoaded(filterName, filterValue, resultCount, arrayOf(
-                Constants.QueryConstants.ACTION to Constants.QueryValues.EVENT_BROWSE_RESULTS
-        ))
+        return dataManager.trackBrowseResultsLoaded(
+                arrayOf(
+                        Constants.QueryConstants.FILTER_NAME to filterName,
+                        Constants.QueryConstants.FILTER_VALUE to filterValue,
+                        Constants.QueryConstants.CLIENT to BuildConfig.CLIENT_VERSION,
+                        Constants.QueryConstants.IDENTITY to preferenceHelper.id,
+                        Constants.QueryConstants.USER_ID to configMemoryHolder.userId,
+                        Constants.QueryConstants.API_KEY to preferenceHelper.apiKey
+                ),
+                arrayOf(
+                        Constants.QueryConstants.SESSION to preferenceHelper.getSessionId(),
+                        Constants.QueryConstants.RESULT_COUNT to resultCount
+                ),
+                configMemoryHolder.segments,
+                arrayOf(
+                        Constants.QueryConstants.ACTION to Constants.QueryValues.EVENT_BROWSE_RESULTS
+                )
+        )
     }
 
     /**
@@ -378,7 +394,22 @@ object ConstructorIo {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         resultID?.let { encodedParams.add(Constants.QueryConstants.RESULT_ID.urlEncode() to it.urlEncode()) }
         val sName = sectionName ?: preferenceHelper.defaultItemSection
-        return dataManager.trackBrowseResultClick(filterName, filterValue, customerId, resultPositionOnPage, arrayOf(
+        return dataManager.trackBrowseResultClick(
+                arrayOf(
+                        Constants.QueryConstants.FILTER_NAME to filterName,
+                        Constants.QueryConstants.FILTER_VALUE to filterValue,
+                        Constants.QueryConstants.CUSTOMER_ID to customerId,
+                        Constants.QueryConstants.CLIENT to BuildConfig.CLIENT_VERSION,
+                        Constants.QueryConstants.IDENTITY to preferenceHelper.id,
+                        Constants.QueryConstants.USER_ID to configMemoryHolder.userId,
+                        Constants.QueryConstants.API_KEY to preferenceHelper.apiKey
+                ),
+                arrayOf(
+                        Constants.QueryConstants.SESSION to preferenceHelper.getSessionId(),
+                        Constants.QueryConstants.RESULT_POSITION_ON_PAGE to resultPositionOnPage
+                ),
+                configMemoryHolder.segments,
+                arrayOf(
                 Constants.QueryConstants.AUTOCOMPLETE_SECTION to sName
         ), encodedParams.toTypedArray())
 

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -11,6 +11,8 @@ import io.constructor.data.model.autocomplete.AutocompleteResponse
 import io.constructor.data.model.common.ResultGroup
 import io.constructor.data.model.search.SearchResponse
 import io.constructor.data.model.browse.BrowseResponse
+import io.constructor.data.model.browse.BrowseResultClickRequestBody
+import io.constructor.data.model.browse.BrowseResultLoadRequestBody
 import io.constructor.injection.component.AppComponent
 import io.constructor.injection.component.DaggerAppComponent
 import io.constructor.injection.module.AppModule
@@ -355,20 +357,23 @@ object ConstructorIo {
     }
     internal fun trackBrowseResultsLoadedInternal(filterName: String?, filterValue: String?, resultCount: Int?): Completable {
         preferenceHelper.getSessionId(sessionIncrementHandler)
-        return dataManager.trackBrowseResultsLoaded(
-                arrayOf(
-                        Constants.QueryConstants.FILTER_NAME to filterName,
-                        Constants.QueryConstants.FILTER_VALUE to filterValue,
-                        Constants.QueryConstants.CLIENT to BuildConfig.CLIENT_VERSION,
-                        Constants.QueryConstants.IDENTITY to preferenceHelper.id,
-                        Constants.QueryConstants.USER_ID to configMemoryHolder.userId,
-                        Constants.QueryConstants.API_KEY to preferenceHelper.apiKey
-                ),
-                arrayOf(
-                        Constants.QueryConstants.SESSION to preferenceHelper.getSessionId(),
-                        Constants.QueryConstants.RESULT_COUNT to resultCount
-                ),
+        val browseResultLoadRequestBody = BrowseResultLoadRequestBody(
+                filterName,
+                filterValue,
+                resultCount,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                configMemoryHolder.userId,
                 configMemoryHolder.segments,
+                preferenceHelper.apiKey,
+                true,
+                preferenceHelper.defaultItemSection,
+                System.currentTimeMillis().toInt()
+        )
+
+        return dataManager.trackBrowseResultsLoaded(
+                browseResultLoadRequestBody,
                 arrayOf(
                         Constants.QueryConstants.ACTION to Constants.QueryValues.EVENT_BROWSE_RESULTS
                 )
@@ -394,24 +399,28 @@ object ConstructorIo {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         resultID?.let { encodedParams.add(Constants.QueryConstants.RESULT_ID.urlEncode() to it.urlEncode()) }
         val sName = sectionName ?: preferenceHelper.defaultItemSection
-        return dataManager.trackBrowseResultClick(
-                arrayOf(
-                        Constants.QueryConstants.FILTER_NAME to filterName,
-                        Constants.QueryConstants.FILTER_VALUE to filterValue,
-                        Constants.QueryConstants.CUSTOMER_ID to customerId,
-                        Constants.QueryConstants.CLIENT to BuildConfig.CLIENT_VERSION,
-                        Constants.QueryConstants.IDENTITY to preferenceHelper.id,
-                        Constants.QueryConstants.USER_ID to configMemoryHolder.userId,
-                        Constants.QueryConstants.API_KEY to preferenceHelper.apiKey
-                ),
-                arrayOf(
-                        Constants.QueryConstants.SESSION to preferenceHelper.getSessionId(),
-                        Constants.QueryConstants.RESULT_POSITION_ON_PAGE to resultPositionOnPage
-                ),
+        val browseResultClickRequestBody = BrowseResultClickRequestBody(
+                filterName,
+                filterValue,
+                customerId,
+                resultPositionOnPage,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                configMemoryHolder.userId,
                 configMemoryHolder.segments,
+                preferenceHelper.apiKey,
+                true,
+                sName,
+                System.currentTimeMillis().toInt()
+        )
+
+        return dataManager.trackBrowseResultClick(
+                browseResultClickRequestBody,
                 arrayOf(
                         Constants.QueryConstants.AUTOCOMPLETE_SECTION to sName
-                ), encodedParams.toTypedArray())
+                ), encodedParams.toTypedArray()
+        )
 
     }
 

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -410,8 +410,8 @@ object ConstructorIo {
                 ),
                 configMemoryHolder.segments,
                 arrayOf(
-                Constants.QueryConstants.AUTOCOMPLETE_SECTION to sName
-        ), encodedParams.toTypedArray())
+                        Constants.QueryConstants.AUTOCOMPLETE_SECTION to sName
+                ), encodedParams.toTypedArray())
 
     }
 

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -117,49 +117,12 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
         }.toObservable()
     }
 
-    fun trackBrowseResultsLoaded(requestBodyStringParams: Array<Pair<String, String?>>, requestBodyIntParams: Array<Pair<String, Int?>>, segments: List<String?>, params: Array<Pair<String, String>>): Completable {
-        val requestBodyStringParamsMap = requestBodyStringParams.toMap()
-        val requestBodyIntParamsMap = requestBodyIntParams.toMap()
-        val urlParamsMap = params.toMap()
-
-        val browseRequestBody = BrowseResultLoadRequestBody(
-                requestBodyStringParamsMap["filter_name"],
-                requestBodyStringParamsMap["filter_value"],
-                requestBodyIntParamsMap["result_count"],
-                requestBodyStringParamsMap["c"],
-                requestBodyStringParamsMap["i"],
-                requestBodyIntParamsMap["s"],
-                requestBodyStringParamsMap["ui"],
-                segments,
-                requestBodyStringParamsMap["key"],
-                true,
-                urlParamsMap["autocomplete_section"],
-                System.currentTimeMillis().toInt()
-        )
-        return constructorApi.trackBrowseResultsLoaded(browseRequestBody, urlParamsMap)
+    fun trackBrowseResultsLoaded(browseResultLoadRequestBody: BrowseResultLoadRequestBody, params: Array<Pair<String, String>>): Completable {
+        return constructorApi.trackBrowseResultsLoaded(browseResultLoadRequestBody, params.toMap())
     }
 
-    fun trackBrowseResultClick(requestBodyStringParams: Array<Pair<String, String?>>, requestBodyIntParams: Array<Pair<String, Int?>>, segments: List<String?>, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
-        val requestBodyStringParamsMap = requestBodyStringParams.toMap()
-        val requestBodyIntParamsMap = requestBodyIntParams.toMap()
-        val urlParamsMap = params.toMap()
-
-        val browseRequestBody = BrowseResultClickRequestBody(
-                requestBodyStringParamsMap["filter_name"],
-                requestBodyStringParamsMap["filter_value"],
-                requestBodyStringParamsMap["customer_id"],
-                requestBodyIntParamsMap["result_position_on_page"],
-                requestBodyStringParamsMap["c"],
-                requestBodyStringParamsMap["i"],
-                requestBodyIntParamsMap["s"],
-                requestBodyStringParamsMap["ui"],
-                segments,
-                requestBodyStringParamsMap["key"],
-                true,
-                urlParamsMap["autocomplete_section"],
-                System.currentTimeMillis().toInt()
-        )
-        return constructorApi.trackBrowseResultClick(browseRequestBody, urlParamsMap, encodedParams.toMap())
+    fun trackBrowseResultClick(browseResultClickRequestBody: BrowseResultClickRequestBody, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
+        return constructorApi.trackBrowseResultClick(browseResultClickRequestBody, params.toMap(), encodedParams.toMap())
     }
 
 }

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -4,7 +4,8 @@ import com.squareup.moshi.Moshi
 import io.constructor.data.model.autocomplete.AutocompleteResponse
 import io.constructor.data.model.search.SearchResponse
 import io.constructor.data.model.browse.BrowseResponse
-import io.constructor.data.model.browse.BrowseRequestBody
+import io.constructor.data.model.browse.BrowseResultClickRequestBody
+import io.constructor.data.model.browse.BrowseResultLoadRequestBody
 import io.constructor.data.remote.ApiPaths
 import io.constructor.data.remote.ConstructorApi
 import io.reactivex.Completable
@@ -117,12 +118,12 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
     }
 
     fun trackBrowseResultClick(filterName: String, filterValue: String, customerId: String, resultPositionOnPage: Int, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
-        val browseRequestBody = BrowseRequestBody(filterName, filterValue, null, customerId, resultPositionOnPage)
+        val browseRequestBody = BrowseResultClickRequestBody(filterName, filterValue, customerId, resultPositionOnPage)
         return constructorApi.trackBrowseResultClick(browseRequestBody, params.toMap(), encodedParams.toMap())
     }
 
     fun trackBrowseResultsLoaded(filterName: String, filterValue: String, resultCount: Int, params: Array<Pair<String, String>>): Completable {
-        val browseRequestBody = BrowseRequestBody(filterName, filterValue, resultCount, null, null)
+        val browseRequestBody = BrowseResultLoadRequestBody(filterName, filterValue, resultCount)
         return constructorApi.trackBrowseResultsLoaded(browseRequestBody, params.toMap())
     }
 

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -117,14 +117,49 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
         }.toObservable()
     }
 
-    fun trackBrowseResultClick(filterName: String, filterValue: String, customerId: String, resultPositionOnPage: Int, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
-        val browseRequestBody = BrowseResultClickRequestBody(filterName, filterValue, customerId, resultPositionOnPage)
-        return constructorApi.trackBrowseResultClick(browseRequestBody, params.toMap(), encodedParams.toMap())
+    fun trackBrowseResultsLoaded(requestBodyStringParams: Array<Pair<String, String?>>, requestBodyIntParams: Array<Pair<String, Int?>>, segments: List<String?>, params: Array<Pair<String, String>>): Completable {
+        val requestBodyStringParamsMap = requestBodyStringParams.toMap()
+        val requestBodyIntParamsMap = requestBodyIntParams.toMap()
+        val urlParamsMap = params.toMap()
+
+        val browseRequestBody = BrowseResultLoadRequestBody(
+                requestBodyStringParamsMap["filter_name"],
+                requestBodyStringParamsMap["filter_value"],
+                requestBodyIntParamsMap["result_count"],
+                requestBodyStringParamsMap["c"],
+                requestBodyStringParamsMap["i"],
+                requestBodyIntParamsMap["s"],
+                requestBodyStringParamsMap["ui"],
+                segments,
+                requestBodyStringParamsMap["key"],
+                true,
+                urlParamsMap["autocomplete_section"],
+                System.currentTimeMillis().toInt()
+        )
+        return constructorApi.trackBrowseResultsLoaded(browseRequestBody, urlParamsMap)
     }
 
-    fun trackBrowseResultsLoaded(filterName: String, filterValue: String, resultCount: Int, params: Array<Pair<String, String>>): Completable {
-        val browseRequestBody = BrowseResultLoadRequestBody(filterName, filterValue, resultCount)
-        return constructorApi.trackBrowseResultsLoaded(browseRequestBody, params.toMap())
+    fun trackBrowseResultClick(requestBodyStringParams: Array<Pair<String, String?>>, requestBodyIntParams: Array<Pair<String, Int?>>, segments: List<String?>, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
+        val requestBodyStringParamsMap = requestBodyStringParams.toMap()
+        val requestBodyIntParamsMap = requestBodyIntParams.toMap()
+        val urlParamsMap = params.toMap()
+
+        val browseRequestBody = BrowseResultClickRequestBody(
+                requestBodyStringParamsMap["filter_name"],
+                requestBodyStringParamsMap["filter_value"],
+                requestBodyStringParamsMap["customer_id"],
+                requestBodyIntParamsMap["result_position_on_page"],
+                requestBodyStringParamsMap["c"],
+                requestBodyStringParamsMap["i"],
+                requestBodyIntParamsMap["s"],
+                requestBodyStringParamsMap["ui"],
+                segments,
+                requestBodyStringParamsMap["key"],
+                true,
+                urlParamsMap["autocomplete_section"],
+                System.currentTimeMillis().toInt()
+        )
+        return constructorApi.trackBrowseResultClick(browseRequestBody, urlParamsMap, encodedParams.toMap())
     }
 
 }

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import io.constructor.data.model.autocomplete.AutocompleteResponse
 import io.constructor.data.model.search.SearchResponse
 import io.constructor.data.model.browse.BrowseResponse
+import io.constructor.data.model.browse.BrowseRequestBody
 import io.constructor.data.remote.ApiPaths
 import io.constructor.data.remote.ConstructorApi
 import io.reactivex.Completable
@@ -116,11 +117,13 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
     }
 
     fun trackBrowseResultClick(filterName: String, filterValue: String, customerId: String, resultPositionOnPage: Int, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
-        return constructorApi.trackBrowseResultClick(filterName, filterValue, customerId, resultPositionOnPage, params.toMap(), encodedParams.toMap())
+        val browseRequestBody = BrowseRequestBody(filterName, filterValue, null, customerId, resultPositionOnPage)
+        return constructorApi.trackBrowseResultClick(browseRequestBody, params.toMap(), encodedParams.toMap())
     }
 
     fun trackBrowseResultsLoaded(filterName: String, filterValue: String, resultCount: Int, params: Array<Pair<String, String>>): Completable {
-        return constructorApi.trackBrowseResultsLoaded(filterName, filterValue, resultCount, params.toMap())
+        val browseRequestBody = BrowseRequestBody(filterName, filterValue, resultCount, null, null)
+        return constructorApi.trackBrowseResultsLoaded(browseRequestBody, params.toMap())
     }
 
 }

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseRequestBody.kt
@@ -1,0 +1,13 @@
+package io.constructor.data.model.browse
+
+import com.squareup.moshi.Json
+import io.constructor.data.model.common.*;
+import java.io.Serializable
+
+data class BrowseRequestBody(
+        @Json(name = "filter_name") val filterName: String?,
+        @Json(name = "filter_value") val filterValue: String?,
+        @Json(name = "result_count") val resultCount: Int?,
+        @Json(name = "customer_id") val customerId: String?,
+        @Json(name = "result_position_on_page") val resultPositionOnPage: Int?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseRequestBody.kt
@@ -5,8 +5,8 @@ import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 data class BrowseRequestBody(
-        @Json(name = "filter_name") val filterName: String?,
-        @Json(name = "filter_value") val filterValue: String?,
+        @Json(name = "filter_name") val filterName: String,
+        @Json(name = "filter_value") val filterValue: String,
         @Json(name = "result_count") val resultCount: Int?,
         @Json(name = "customer_id") val customerId: String?,
         @Json(name = "result_position_on_page") val resultPositionOnPage: Int?

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
@@ -4,10 +4,9 @@ import com.squareup.moshi.Json
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
-data class BrowseRequestBody(
+data class BrowseResultClickRequestBody(
         @Json(name = "filter_name") val filterName: String,
         @Json(name = "filter_value") val filterValue: String,
-        @Json(name = "result_count") val resultCount: Int?,
         @Json(name = "customer_id") val customerId: String?,
         @Json(name = "result_position_on_page") val resultPositionOnPage: Int?
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
@@ -5,8 +5,17 @@ import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 data class BrowseResultClickRequestBody(
-        @Json(name = "filter_name") val filterName: String,
-        @Json(name = "filter_value") val filterValue: String,
-        @Json(name = "customer_id") val customerId: String?,
-        @Json(name = "result_position_on_page") val resultPositionOnPage: Int?
+        @Json(name = "filter_name") val filterName: String?,
+        @Json(name = "filter_value") val filterValue: String?,
+        @Json(name = "item_id") val item_id: String?,
+        @Json(name = "result_position_on_page") val resultPositionOnPage: Int?,
+        @Json(name = "c") val c: String?,
+        @Json(name = "i") val i: String?,
+        @Json(name = "s") val s: Int?,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "key") val key: String?,
+        @Json(name= "beacon") val beacon: Boolean?,
+        @Json(name= "autocomplete_section") val autocomplete_section: String?,
+        @Json(name= "_dt") val _dt: Int?
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
@@ -5,17 +5,17 @@ import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 data class BrowseResultClickRequestBody(
-        @Json(name = "filter_name") val filterName: String?,
-        @Json(name = "filter_value") val filterValue: String?,
-        @Json(name = "item_id") val item_id: String?,
-        @Json(name = "result_position_on_page") val resultPositionOnPage: Int?,
-        @Json(name = "c") val c: String?,
-        @Json(name = "i") val i: String?,
-        @Json(name = "s") val s: Int?,
+        @Json(name = "filter_name") val filterName: String,
+        @Json(name = "filter_value") val filterValue: String,
+        @Json(name = "item_id") val item_id: String,
+        @Json(name = "result_position_on_page") val resultPositionOnPage: Int,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
-        @Json(name = "key") val key: String?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "autocomplete_section") val autocomplete_section: String?,
-        @Json(name= "_dt") val _dt: Int?
+        @Json(name= "_dt") val _dt: String?
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
@@ -5,16 +5,16 @@ import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 data class BrowseResultLoadRequestBody(
-        @Json(name = "filter_name") val filterName: String?,
-        @Json(name = "filter_value") val filterValue: String?,
-        @Json(name = "result_count") val resultCount: Int?,
-        @Json(name = "c") val c: String?,
-        @Json(name = "i") val i: String?,
-        @Json(name = "s") val s: Int?,
+        @Json(name = "filter_name") val filterName: String,
+        @Json(name = "filter_value") val filterValue: String,
+        @Json(name = "result_count") val resultCount: Int,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
-        @Json(name = "key") val key: String?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "autocomplete_section") val autocomplete_section: String?,
-        @Json(name= "_dt") val _dt: Int?
+        @Json(name= "_dt") val _dt: String?
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
@@ -5,7 +5,16 @@ import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 data class BrowseResultLoadRequestBody(
-        @Json(name = "filter_name") val filterName: String,
-        @Json(name = "filter_value") val filterValue: String,
-        @Json(name = "result_count") val resultCount: Int?
+        @Json(name = "filter_name") val filterName: String?,
+        @Json(name = "filter_value") val filterValue: String?,
+        @Json(name = "result_count") val resultCount: Int?,
+        @Json(name = "c") val c: String?,
+        @Json(name = "i") val i: String?,
+        @Json(name = "s") val s: Int?,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "key") val key: String?,
+        @Json(name= "beacon") val beacon: Boolean?,
+        @Json(name= "autocomplete_section") val autocomplete_section: String?,
+        @Json(name= "_dt") val _dt: Int?
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
@@ -1,0 +1,11 @@
+package io.constructor.data.model.browse
+
+import com.squareup.moshi.Json
+import io.constructor.data.model.common.*;
+import java.io.Serializable
+
+data class BrowseResultLoadRequestBody(
+        @Json(name = "filter_name") val filterName: String,
+        @Json(name = "filter_value") val filterValue: String,
+        @Json(name = "result_count") val resultCount: Int?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -61,7 +61,7 @@ interface ConstructorApi {
     @GET
     fun getBrowseResults(@Url browseUrl: String): Single<Result<ResponseBody>>
 
-    @GET(ApiPaths.URL_BROWSE_RESULT_CLICK_EVENT)
+    @POST(ApiPaths.URL_BROWSE_RESULT_CLICK_EVENT)
     fun trackBrowseResultClick(@Query("filter_name") filterName: String,
                                @Query("filter_value") filterValue: String,
                                @Query("customer_id") customerId: String,
@@ -69,7 +69,7 @@ interface ConstructorApi {
                                @QueryMap params: Map<String, String>,
                                @QueryMap(encoded = true) encodedData: Map<String, String>): Completable
 
-    @GET(ApiPaths.URL_BROWSE_RESULT_LOAD_EVENT)
+    @POST(ApiPaths.URL_BROWSE_RESULT_LOAD_EVENT)
     fun trackBrowseResultsLoaded(@Query("filter_name") filterName: String,
                                  @Query("filter_value") filterValue: String,
                                  @Query("num_results") resultCount: Int,

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -2,7 +2,8 @@ package io.constructor.data.remote
 
 import io.constructor.core.Constants
 import io.constructor.data.model.autocomplete.AutocompleteResponse
-import io.constructor.data.model.browse.BrowseRequestBody
+import io.constructor.data.model.browse.BrowseResultClickRequestBody
+import io.constructor.data.model.browse.BrowseResultLoadRequestBody
 import io.reactivex.Completable
 import io.reactivex.Single
 import okhttp3.ResponseBody
@@ -63,12 +64,12 @@ interface ConstructorApi {
     fun getBrowseResults(@Url browseUrl: String): Single<Result<ResponseBody>>
 
     @POST(ApiPaths.URL_BROWSE_RESULT_CLICK_EVENT)
-    fun trackBrowseResultClick(@Body browseRequestBody: BrowseRequestBody,
+    fun trackBrowseResultClick(@Body browseResultClickRequestBody: BrowseResultClickRequestBody,
                                @QueryMap params: Map<String, String>,
                                @QueryMap(encoded = true) encodedData: Map<String, String>): Completable
 
     @POST(ApiPaths.URL_BROWSE_RESULT_LOAD_EVENT)
-    fun trackBrowseResultsLoaded(@Body browseRequestBody: BrowseRequestBody,
+    fun trackBrowseResultsLoaded(@Body browseRequestBody: BrowseResultLoadRequestBody,
                                  @QueryMap params: Map<String, String>): Completable
 
 }

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -2,6 +2,7 @@ package io.constructor.data.remote
 
 import io.constructor.core.Constants
 import io.constructor.data.model.autocomplete.AutocompleteResponse
+import io.constructor.data.model.browse.BrowseRequestBody
 import io.reactivex.Completable
 import io.reactivex.Single
 import okhttp3.ResponseBody
@@ -62,17 +63,12 @@ interface ConstructorApi {
     fun getBrowseResults(@Url browseUrl: String): Single<Result<ResponseBody>>
 
     @POST(ApiPaths.URL_BROWSE_RESULT_CLICK_EVENT)
-    fun trackBrowseResultClick(@Query("filter_name") filterName: String,
-                               @Query("filter_value") filterValue: String,
-                               @Query("customer_id") customerId: String,
-                               @Query("result_position_on_page") resultPositionOnPage: Int,
+    fun trackBrowseResultClick(@Body browseRequestBody: BrowseRequestBody,
                                @QueryMap params: Map<String, String>,
                                @QueryMap(encoded = true) encodedData: Map<String, String>): Completable
 
     @POST(ApiPaths.URL_BROWSE_RESULT_LOAD_EVENT)
-    fun trackBrowseResultsLoaded(@Query("filter_name") filterName: String,
-                                 @Query("filter_value") filterValue: String,
-                                 @Query("num_results") resultCount: Int,
+    fun trackBrowseResultsLoaded(@Body browseRequestBody: BrowseRequestBody,
                                  @QueryMap params: Map<String, String>): Completable
 
 }

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -65,7 +65,7 @@ interface ConstructorApi {
 
     @POST(ApiPaths.URL_BROWSE_RESULT_CLICK_EVENT)
     fun trackBrowseResultClick(@Body browseResultClickRequestBody: BrowseResultClickRequestBody,
-                               @QueryMap params: Map<String, String>,
+                               @QueryMap params: Map<String, String?>,
                                @QueryMap(encoded = true) encodedData: Map<String, String>): Completable
 
     @POST(ApiPaths.URL_BROWSE_RESULT_LOAD_EVENT)

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -368,7 +368,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
-        assertEquals(193, request.bodySize)
+        assertEquals(227, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -381,7 +381,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
-        assertEquals(193, request.bodySize)
+        assertEquals(227, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -405,7 +405,9 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(237, request.bodySize)
+        print(request.body.readUtf8())
+
+        assertEquals(262, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -418,7 +420,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(237, request.bodySize)
+        assertEquals(262, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -431,7 +433,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(237, request.bodySize)
+        assertEquals(262, request.bodySize)
         assertEquals("POST", request.method)
     }
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -15,6 +15,7 @@ import org.junit.Rule
 import org.junit.Test
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
 
 class ConstructorIoTest {
 
@@ -366,6 +367,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?filter_name=group_id&filter_value=Movies&num_results=10&action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
     @Test
@@ -377,6 +379,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?filter_name=group_id&filter_value=Movies&num_results=10&action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
     @Test
@@ -389,6 +392,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?filter_name=group_id&filter_value=Movies&num_results=10&action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
     @Test
@@ -400,6 +404,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
     @Test
@@ -411,6 +416,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
     @Test
@@ -422,6 +428,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
     @Test
@@ -434,6 +441,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals("POST", request.method)
     }
 
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -368,7 +368,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
-        assertEquals(68, request.bodySize)
+        assertEquals(193, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -381,7 +381,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
-        assertEquals(68, request.bodySize)
+        assertEquals(193, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -405,7 +405,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(107, request.bodySize)
+        assertEquals(237, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -418,7 +418,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(107, request.bodySize)
+        assertEquals(237, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -431,7 +431,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(107, request.bodySize)
+        assertEquals(237, request.bodySize)
         assertEquals("POST", request.method)
     }
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -366,7 +366,7 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultsLoadedInternal("group_id", "Movies", 10).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
         assertEquals(68, request.bodySize)
         assertEquals("POST", request.method)
@@ -379,7 +379,7 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultsLoadedInternal("group_id", "Movies", 10).test()
         observer.assertError { true }
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
         assertEquals(68, request.bodySize)
         assertEquals("POST", request.method)
@@ -403,7 +403,7 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
         assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)
@@ -416,7 +416,7 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4, "Products", "3467632").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
         assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)
@@ -429,7 +429,7 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
         observer.assertError { true }
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
         assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ConstructorIoTest {
 
@@ -367,8 +368,9 @@ class ConstructorIoTest {
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
+        print(request.body.readUtf8())
         assert(request.path.startsWith(path))
-        assertEquals(227, request.bodySize)
+        assertTrue(request.bodySize > 220)
         assertEquals("POST", request.method)
     }
 
@@ -381,7 +383,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt="
         assert(request.path.startsWith(path))
-        assertEquals(227, request.bodySize)
+        assertTrue(request.bodySize > 220)
         assertEquals("POST", request.method)
     }
 
@@ -404,10 +406,9 @@ class ConstructorIoTest {
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
-        assert(request.path.startsWith(path))
         print(request.body.readUtf8())
-
-        assertEquals(262, request.bodySize)
+        assert(request.path.startsWith(path))
+        assertTrue(request.bodySize > 250)
         assertEquals("POST", request.method)
     }
 
@@ -420,7 +421,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(262, request.bodySize)
+        assertTrue(request.bodySize > 250)
         assertEquals("POST", request.method)
     }
 
@@ -433,7 +434,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.1&_dt=";
         assert(request.path.startsWith(path))
-        assertEquals(262, request.bodySize)
+        assertTrue(request.bodySize > 250)
         assertEquals("POST", request.method)
     }
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -16,7 +16,6 @@ import org.junit.Test
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 class ConstructorIoTest {
 
@@ -357,7 +356,6 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/autocomplete/TERM_UNKNOWN/purchase?customer_ids=TIT-REP-1997&customer_ids=QE2-REP-1969&revenue=12.99&order_id=ORD-1312343&autocomplete_section=Recommendations&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
-        print(request.body)
     }
 
     @Test
@@ -368,8 +366,8 @@ class ConstructorIoTest {
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
-        assertEquals(68, request.bodySize)
         assert(request.path.startsWith(path))
+        assertEquals(68, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -381,8 +379,8 @@ class ConstructorIoTest {
         observer.assertError { true }
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
-        assertEquals(68, request.bodySize)
         assert(request.path.startsWith(path))
+        assertEquals(68, request.bodySize)
         assertEquals("POST", request.method)
     }
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class ConstructorIoTest {
 
@@ -356,6 +357,7 @@ class ConstructorIoTest {
         val request = mockServer.takeRequest()
         val path = "/autocomplete/TERM_UNKNOWN/purchase?customer_ids=TIT-REP-1997&customer_ids=QE2-REP-1969&revenue=12.99&order_id=ORD-1312343&autocomplete_section=Recommendations&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        print(request.body)
     }
 
     @Test
@@ -365,7 +367,8 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultsLoadedInternal("group_id", "Movies", 10).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_load?filter_name=group_id&filter_value=Movies&num_results=10&action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        assertEquals(68, request.bodySize)
         assert(request.path.startsWith(path))
         assertEquals("POST", request.method)
     }
@@ -377,7 +380,8 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultsLoadedInternal("group_id", "Movies", 10).test()
         observer.assertError { true }
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_load?filter_name=group_id&filter_value=Movies&num_results=10&action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        assertEquals(68, request.bodySize)
         assert(request.path.startsWith(path))
         assertEquals("POST", request.method)
     }
@@ -390,7 +394,8 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultsLoadedInternal("group_id", "Movies", 10).test()
         observer.assertError(SocketTimeoutException::class.java)
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_load?filter_name=group_id&filter_value=Movies&num_results=10&action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        assertEquals(68, request.bodySize)
         assert(request.path.startsWith(path))
         assertEquals("POST", request.method)
     }
@@ -402,8 +407,9 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -414,8 +420,9 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4, "Products", "3467632").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -426,8 +433,9 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
         observer.assertError { true }
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)
     }
 
@@ -439,8 +447,9 @@ class ConstructorIoTest {
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
         observer.assertError(SocketTimeoutException::class.java)
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?filter_name=group_id&filter_value=Movies&customer_id=TIT-REP-1997&result_position_on_page=4&autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
+        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
         assert(request.path.startsWith(path))
+        assertEquals(107, request.bodySize)
         assertEquals("POST", request.method)
     }
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -393,11 +393,8 @@ class ConstructorIoTest {
         mockServer.enqueue(mockResponse)
         val observer = ConstructorIo.trackBrowseResultsLoadedInternal("group_id", "Movies", 10).test()
         observer.assertError(SocketTimeoutException::class.java)
-        val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_load?action=browse-results&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
-        assertEquals(68, request.bodySize)
-        assert(request.path.startsWith(path))
-        assertEquals("POST", request.method)
+        val request = mockServer.takeRequest(10, TimeUnit.SECONDS)
+        assertEquals(null, request)
     }
 
     @Test
@@ -446,11 +443,8 @@ class ConstructorIoTest {
         mockServer.enqueue(mockResponse)
         val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
         observer.assertError(SocketTimeoutException::class.java)
-        val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/browse_result_click?autocomplete_section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.3.0&_dt=";
-        assert(request.path.startsWith(path))
-        assertEquals(107, request.bodySize)
-        assertEquals("POST", request.method)
+        val request = mockServer.takeRequest(10, TimeUnit.SECONDS)
+        assertEquals(null, request)
     }
 
 }


### PR DESCRIPTION
- Using POST method for browse tracking functions
- Send key/value fields (filterValue, filterName, etc...) through request body instead of params