### PR TITLE
Use AndroidX instead of Android Support Libraries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ org.gradle.configureondemand=true
 # Set to true or false to enable or disable the build cache.
 #If this parameter is not set, the build cache is disabled by default.
 android.enableBuildCache=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -169,8 +169,8 @@ dependencies {
     implementation supportLibs
     implementation networkLibs
     implementation otherLibs
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.android.support:cardview-v7:28.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
     kapt annotationProcessorLibs
     kaptTest daggerCompiler
     kaptAndroidTest daggerCompiler

--- a/library/src/main/java/io/constructor/features/base/BaseActivity.kt
+++ b/library/src/main/java/io/constructor/features/base/BaseActivity.kt
@@ -1,9 +1,9 @@
 package io.constructor.features.base
 
 import android.os.Bundle
-import android.support.annotation.LayoutRes
-import android.support.v4.util.LongSparseArray
-import android.support.v7.app.AppCompatActivity
+import androidx.annotation.LayoutRes
+import androidx.collection.LongSparseArray
+import androidx.appcompat.app.AppCompatActivity
 import android.view.MenuItem
 import io.constructor.core.ConstructorIo
 import io.constructor.injection.component.ActivityComponent

--- a/library/src/main/java/io/constructor/features/base/BaseFragment.kt
+++ b/library/src/main/java/io/constructor/features/base/BaseFragment.kt
@@ -1,8 +1,8 @@
 package io.constructor.features.base
 
 import android.os.Bundle
-import android.support.annotation.LayoutRes
-import android.support.v4.app.Fragment
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
 import android.util.LongSparseArray
 import android.view.LayoutInflater
 import android.view.View

--- a/library/src/main/java/io/constructor/injection/module/FragmentModule.kt
+++ b/library/src/main/java/io/constructor/injection/module/FragmentModule.kt
@@ -1,8 +1,8 @@
 package io.constructor.injection.module
 
 import android.content.Context
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import dagger.Module
 import dagger.Provides
 import io.constructor.injection.ActivityContext

--- a/library/src/main/java/io/constructor/ui/base/BaseSuggestionFragment.kt
+++ b/library/src/main/java/io/constructor/ui/base/BaseSuggestionFragment.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
-import android.support.v4.content.LocalBroadcastManager
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import android.text.Editable
 import android.text.TextUtils
 import android.text.TextWatcher

--- a/library/src/main/java/io/constructor/ui/base/BaseSuggestionsAdapter.kt
+++ b/library/src/main/java/io/constructor/ui/base/BaseSuggestionsAdapter.kt
@@ -2,9 +2,9 @@ package io.constructor.ui.base
 
 import android.graphics.Color
 import android.graphics.Typeface
-import android.support.annotation.IdRes
-import android.support.annotation.LayoutRes
-import android.support.v7.widget.RecyclerView
+import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.RecyclerView
 import android.text.Spannable
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan

--- a/library/src/main/java/io/constructor/util/Extensions.kt
+++ b/library/src/main/java/io/constructor/util/Extensions.kt
@@ -3,7 +3,7 @@ package io.constructor.util
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
-import android.support.v4.content.LocalBroadcastManager
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import android.util.Base64
 import android.util.Log
 import io.reactivex.Observable

--- a/library/src/main/res/layout/fragment_suggestions.xml
+++ b/library/src/main/res/layout/fragment_suggestions.xml
@@ -46,17 +46,17 @@
 
     </RelativeLayout>
 
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/searchContainer"
         android:layout_margin="8dp">
 
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/suggestionItems"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-    </android.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 
 </RelativeLayout>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -28,14 +28,14 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':library')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation "com.android.support:cardview-v7:28.0.0"
-    implementation "com.android.support:design:28.0.0"
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.6'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.2.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.github.bumptech.glide:glide:4.9.0'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
     testImplementation 'junit:junit:4.12'

--- a/sample/src/main/java/io/constructor/sample/common/BaseActivity.kt
+++ b/sample/src/main/java/io/constructor/sample/common/BaseActivity.kt
@@ -1,7 +1,7 @@
 package io.constructor.sample.common
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 
 abstract class BaseActivity<T : BasePresenter<*>> : AppCompatActivity() {
 

--- a/sample/src/main/java/io/constructor/sample/feature/cart/CartActivity.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/cart/CartActivity.kt
@@ -2,7 +2,7 @@ package io.constructor.sample.feature.cart
 
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.widget.LinearLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
 import io.constructor.data.model.common.Result
 import io.constructor.sample.R
 import io.constructor.sample.common.BaseActivity

--- a/sample/src/main/java/io/constructor/sample/feature/cart/CartContentAdapter.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/cart/CartContentAdapter.kt
@@ -1,6 +1,6 @@
 package io.constructor.sample.feature.cart
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/sample/src/main/java/io/constructor/sample/feature/productdetail/ProductDetailActivity.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/productdetail/ProductDetailActivity.kt
@@ -3,7 +3,7 @@ package io.constructor.sample.feature.productdetail
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.design.widget.Snackbar
+import com.google.android.material.snackbar.Snackbar
 import com.bumptech.glide.Glide
 import io.constructor.data.model.common.Result
 import io.constructor.sample.R

--- a/sample/src/main/java/io/constructor/sample/feature/searchresult/SearchResultActivity.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/searchresult/SearchResultActivity.kt
@@ -3,8 +3,8 @@ package io.constructor.sample.feature.searchresult
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.widget.GridLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import io.constructor.data.model.common.Result
 import io.constructor.data.model.search.SearchResponseInner
 import io.constructor.sample.R

--- a/sample/src/main/java/io/constructor/sample/feature/searchresult/SearchResultAdapter.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/searchresult/SearchResultAdapter.kt
@@ -1,6 +1,6 @@
 package io.constructor.sample.feature.searchresult
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/sample/src/main/java/io/constructor/sample/feature/searchresult/filterdialog/FilterDialog.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/searchresult/filterdialog/FilterDialog.kt
@@ -2,9 +2,9 @@ package io.constructor.sample.feature.searchresult.filterdialog
 
 import android.app.Dialog
 import android.os.Bundle
-import android.support.v4.app.DialogFragment
-import android.support.v7.app.AlertDialog
-import android.support.v7.widget.LinearLayoutManager
+import androidx.fragment.app.DialogFragment
+import androidx.appcompat.app.AlertDialog
+import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import io.constructor.data.model.common.FilterFacet

--- a/sample/src/main/java/io/constructor/sample/feature/searchresult/filterdialog/FilterListAdapter.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/searchresult/filterdialog/FilterListAdapter.kt
@@ -1,6 +1,6 @@
 package io.constructor.sample.feature.searchresult.filterdialog
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/sample/src/main/java/io/constructor/sample/feature/searchresult/sortdialog/SortDialog.kt
+++ b/sample/src/main/java/io/constructor/sample/feature/searchresult/sortdialog/SortDialog.kt
@@ -2,8 +2,8 @@ package io.constructor.sample.feature.searchresult.sortdialog
 
 import android.app.Dialog
 import android.os.Bundle
-import android.support.v4.app.DialogFragment
-import android.support.v7.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.appcompat.app.AlertDialog
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.RadioButton

--- a/sample/src/main/res/layout/activity_cart.xml
+++ b/sample/src/main/res/layout/activity_cart.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".feature.home.HomeActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -16,9 +16,9 @@
         app:layout_constraintTop_toTopOf="parent"
         app:titleTextColor="@color/white">
 
-    </android.support.v7.widget.Toolbar>
+    </androidx.appcompat.widget.Toolbar>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/cartContent"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -28,7 +28,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar">
 
-    </android.support.v7.widget.RecyclerView>
+    </androidx.recyclerview.widget.RecyclerView>
 
     <Button
         android:id="@+id/checkout"
@@ -40,4 +40,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_checkout.xml
+++ b/sample/src/main/res/layout/activity_checkout.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".feature.home.HomeActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -16,7 +16,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:titleTextColor="@color/white">
 
-    </android.support.v7.widget.Toolbar>
+    </androidx.appcompat.widget.Toolbar>
 
     <TextView
         android:id="@+id/textView"
@@ -29,4 +29,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_home.xml
+++ b/sample/src/main/res/layout/activity_home.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".feature.home.HomeActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:background="@color/colorPrimary"
         app:titleTextColor="@color/white"
@@ -16,7 +16,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <android.support.v7.widget.AppCompatAutoCompleteTextView
+        <androidx.appcompat.widget.AppCompatAutoCompleteTextView
             android:id="@+id/searchInput"
             android:visibility="gone"
             android:textColor="@color/white"
@@ -25,7 +25,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-    </android.support.v7.widget.Toolbar>
+    </androidx.appcompat.widget.Toolbar>
 
     <TextView
         android:id="@+id/text"
@@ -41,7 +41,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchResult"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -50,4 +50,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_product_detail.xml
+++ b/sample/src/main/res/layout/activity_product_detail.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     tools:context=".feature.home.HomeActivity">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -17,7 +17,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:titleTextColor="@color/white">
 
-    </android.support.v7.widget.Toolbar>
+    </androidx.appcompat.widget.Toolbar>
 
     <ImageView
         android:id="@+id/image"
@@ -52,4 +52,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/price" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -9,4 +9,4 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_search_result.xml
+++ b/sample/src/main/res/layout/activity_search_result.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         app:titleTextColor="@color/white"
@@ -14,9 +14,9 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-    </android.support.v7.widget.Toolbar>
+    </androidx.appcompat.widget.Toolbar>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchResult"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -25,4 +25,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/dialog_filter.xml
+++ b/sample/src/main/res/layout/dialog_filter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -14,7 +14,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/filterList"
         android:layout_width="match_parent"
         android:layout_height="350dp"
@@ -24,7 +24,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/title">
 
-    </android.support.v7.widget.RecyclerView>
+    </androidx.recyclerview.widget.RecyclerView>
 
     <Button
         android:id="@+id/apply"
@@ -50,4 +50,4 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/dialog_sort.xml
+++ b/sample/src/main/res/layout/dialog_sort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -55,4 +55,4 @@
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/fragment_custom_suggestions.xml
+++ b/sample/src/main/res/layout/fragment_custom_suggestions.xml
@@ -5,7 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/white">
 
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:layout_margin="8dp"
         android:id="@+id/searchContainer"
         android:layout_width="match_parent"
@@ -77,7 +77,7 @@
                     android:layout_height="1dp"
                     android:background="@color/light_grey" />
 
-                <android.support.v7.widget.RecyclerView
+                <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/suggestions"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
@@ -107,6 +107,6 @@
                 android:visibility="gone" />
 
         </RelativeLayout>
-    </android.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 
 </RelativeLayout>

--- a/sample/src/main/res/layout/item_cart_content.xml
+++ b/sample/src/main/res/layout/item_cart_content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/rootView"
@@ -89,4 +89,4 @@
         app:layout_constraintStart_toEndOf="@+id/image"
         app:layout_constraintTop_toBottomOf="@+id/quantity" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/item_search_result.xml
+++ b/sample/src/main/res/layout/item_search_result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -11,7 +11,7 @@
     app:cardElevation="8dp"
     app:contentPadding="16dp">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -55,6 +55,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title" />
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
In order to stop allow clients to use the SDK without requiring them to use Jetifier (which can negatively impact build times), the SDK should be upgraded to use the modern AndroidX libraries.

This PR was created using Android Studio's `Migrate to AndroidX` tool.