### PR TITLE
[CSL 390] android sdk add ability to add filters to autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ ConstructorIo.userId = "uid"
 ## 4. Request Autocomplete Results
 
 ```kotlin
-ConstructorIo.getAutocompleteResults("Dav")
+var query = "Dav"
+var selectedFacet: HashMap<String, MutableList<String>>? = null
+
+ConstructorIo.getAutocompleteResults(query, selectedFacet?.map { it.key to it.value })
 .subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread())
 .subscribe {
   it.onValue {

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -117,13 +117,20 @@ object ConstructorIo {
 
     /**
      * Returns a list of autocomplete suggestions
+     * @param term the term to search for
+     * @param facet  single facet used to refine results
      */
-    fun getAutocompleteResults(term: String): Observable<ConstructorData<AutocompleteResponse>> {
-        val params = mutableListOf<Pair<String, String>>()
-        configMemoryHolder.autocompleteResultCount?.entries?.forEach {
-            params.add(Pair(Constants.QueryConstants.NUM_RESULTS+it.key, it.value.toString()))
+    fun getAutocompleteResults(term: String, facet: List<Pair<String, List<String>>>? = null): Observable<ConstructorData<AutocompleteResponse>> {
+        val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
+        facet?.forEach { facet ->
+            facet.second.forEach {
+                encodedParams.add(Constants.QueryConstants.FILTER_FACET.format(facet.first).urlEncode() to it.urlEncode())
+            }
         }
-        return dataManager.getAutocompleteResults(term, params.toTypedArray())
+        configMemoryHolder.autocompleteResultCount?.entries?.forEach {
+            encodedParams.add(Pair(Constants.QueryConstants.NUM_RESULTS+it.key, it.value.toString()))
+        }
+        return dataManager.getAutocompleteResults(term, encodedParams = encodedParams.toTypedArray())
     }
 
     /**

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -119,6 +119,7 @@ object ConstructorIo {
      * Returns a list of autocomplete suggestions
      * @param term the term to search for
      * @param facets additional facets used to refine results
+     * @param groupId category facet used to refine results
      */
     fun getAutocompleteResults(term: String, facets: List<Pair<String, List<String>>>? = null, groupId: Int? = null): Observable<ConstructorData<AutocompleteResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -118,11 +118,12 @@ object ConstructorIo {
     /**
      * Returns a list of autocomplete suggestions
      * @param term the term to search for
-     * @param facet  single facet used to refine results
+     * @param facets additional facets used to refine results
      */
-    fun getAutocompleteResults(term: String, facet: List<Pair<String, List<String>>>? = null): Observable<ConstructorData<AutocompleteResponse>> {
+    fun getAutocompleteResults(term: String, facets: List<Pair<String, List<String>>>? = null, groupId: Int? = null): Observable<ConstructorData<AutocompleteResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
-        facet?.forEach { facet ->
+        groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
+        facets?.forEach { facet ->
             facet.second.forEach {
                 encodedParams.add(Constants.QueryConstants.FILTER_FACET.format(facet.first).urlEncode() to it.urlEncode())
             }

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -24,9 +24,9 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
         encodedParams.forEachIndexed { index, pair ->
             dynamicUrl += "${if (index != 0) "&" else "?" }${pair.first}=${pair.second}"
         }
-        return constructorApi.getAutocompleteResults(dynamicUrl).map {
-            if (!it.isError) {
-                it.response()?.let {
+        return constructorApi.getAutocompleteResults(dynamicUrl).map { result ->
+            if (!result.isError) {
+                result.response()?.let {
                     if (it.isSuccessful) {
                         val adapter = moshi.adapter(AutocompleteResponse::class.java)
                         val response = it.body()?.string()
@@ -36,9 +36,9 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
                     } else {
                         ConstructorData.networkError(it.errorBody()?.string())
                     }
-                } ?: ConstructorData.error(it.error())
+                } ?: ConstructorData.error(result.error())
             } else {
-                ConstructorData.error(it.error())
+                ConstructorData.error(result.error())
             }
         }.toObservable()
     }

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -20,11 +20,7 @@ class DataManager @Inject
 constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi) {
 
     fun getAutocompleteResults(term: String, encodedParams: Array<Pair<String, String>> = arrayOf()): Observable<ConstructorData<AutocompleteResponse>> {
-        var dynamicUrl = "/${ApiPaths.URL_AUTOCOMPLETE.format(term)}"
-        encodedParams.forEachIndexed { index, pair ->
-            dynamicUrl += "${if (index != 0) "&" else "?" }${pair.first}=${pair.second}"
-        }
-        return constructorApi.getAutocompleteResults(dynamicUrl).map { result ->
+        return constructorApi.getAutocompleteResults(term, encodedParams.toMap()).map { result ->
             if (!result.isError) {
                 result.response()?.let {
                     if (it.isSuccessful) {
@@ -44,11 +40,7 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
     }
 
     fun getSearchResults(term: String, encodedParams: Array<Pair<String, String>>? = arrayOf()): Observable<ConstructorData<SearchResponse>> {
-        var dynamicUrl = "/${ApiPaths.URL_SEARCH.format(term)}"
-        encodedParams?.forEachIndexed { index, pair ->
-            dynamicUrl += "${if (index != 0) "&" else "?" }${pair.first}=${pair.second}"
-        }
-        return constructorApi.getSearchResults(dynamicUrl).map { result ->
+        return constructorApi.getSearchResults(term, encodedParams?.toMap()).map { result ->
             if (!result.isError) {
                 result.response()?.let {
                     if (it.isSuccessful){
@@ -100,11 +92,7 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
     }
 
     fun getBrowseResults(filterName: String, filterValue: String, encodedParams: Array<Pair<String, String>> = arrayOf()): Observable<ConstructorData<BrowseResponse>> {
-        var dynamicUrl = "/${ApiPaths.URL_BROWSE.format(filterName, filterValue)}"
-        encodedParams.forEachIndexed { index, pair ->
-            dynamicUrl += "${if (index != 0) "&" else "?" }${pair.first}=${pair.second}"
-        }
-        return constructorApi.getBrowseResults(dynamicUrl).map { result ->
+        return constructorApi.getBrowseResults(filterName, filterValue, encodedParams.toMap()).map { result ->
             if (!result.isError) {
                 result.response()?.let {
                     if (it.isSuccessful){

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -19,8 +19,12 @@ import javax.inject.Singleton
 class DataManager @Inject
 constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi) {
 
-    fun getAutocompleteResults(term: String, params: Array<Pair<String, String>> = arrayOf()): Observable<ConstructorData<AutocompleteResponse>> {
-        return constructorApi.getAutocompleteResults(term, params.toMap()).map {
+    fun getAutocompleteResults(term: String, encodedParams: Array<Pair<String, String>> = arrayOf()): Observable<ConstructorData<AutocompleteResponse>> {
+        var dynamicUrl = "/${ApiPaths.URL_AUTOCOMPLETE.format(term)}"
+        encodedParams.forEachIndexed { index, pair ->
+            dynamicUrl += "${if (index != 0) "&" else "?" }${pair.first}=${pair.second}"
+        }
+        return constructorApi.getAutocompleteResults(dynamicUrl).map {
             if (!it.isError) {
                 it.response()?.let {
                     if (it.isSuccessful) {

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -43,9 +43,9 @@ constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi
         }.toObservable()
     }
 
-    fun getSearchResults(term: String, encodedParams: Array<Pair<String, String>> = arrayOf()): Observable<ConstructorData<SearchResponse>> {
+    fun getSearchResults(term: String, encodedParams: Array<Pair<String, String>>? = arrayOf()): Observable<ConstructorData<SearchResponse>> {
         var dynamicUrl = "/${ApiPaths.URL_SEARCH.format(term)}"
-        encodedParams.forEachIndexed { index, pair ->
+        encodedParams?.forEachIndexed { index, pair ->
             dynamicUrl += "${if (index != 0) "&" else "?" }${pair.first}=${pair.second}"
         }
         return constructorApi.getSearchResults(dynamicUrl).map { result ->

--- a/library/src/main/java/io/constructor/data/remote/ApiPaths.kt
+++ b/library/src/main/java/io/constructor/data/remote/ApiPaths.kt
@@ -1,7 +1,7 @@
 package io.constructor.data.remote
 
 object ApiPaths {
-    const val URL_AUTOCOMPLETE = "autocomplete/%s"
+    const val URL_AUTOCOMPLETE = "autocomplete/{term}"
     const val URL_AUTOCOMPLETE_SELECT_EVENT = "autocomplete/{term}/select"
     const val URL_SEARCH_SUBMIT_EVENT = "autocomplete/{term}/search"
     const val URL_SESSION_START_EVENT = "behavior"
@@ -9,8 +9,8 @@ object ApiPaths {
     const val URL_SEARCH_RESULT_CLICK_EVENT = "autocomplete/{term}/click_through"
     const val URL_BEHAVIOR = "behavior"
     const val URL_PURCHASE = "v2/behavioral_action/purchase"
-    const val URL_SEARCH = "search/%s"
-    const val URL_BROWSE = "browse/%s/%s"
+    const val URL_SEARCH = "search/{term}"
+    const val URL_BROWSE = "browse/{filter_name}/{filter_value}"
     const val URL_BROWSE_RESULT_CLICK_EVENT = "v2/behavioral_action/browse_result_click"
     const val URL_BROWSE_RESULT_LOAD_EVENT = "v2/behavioral_action/browse_result_load"
 }

--- a/library/src/main/java/io/constructor/data/remote/ApiPaths.kt
+++ b/library/src/main/java/io/constructor/data/remote/ApiPaths.kt
@@ -1,7 +1,7 @@
 package io.constructor.data.remote
 
 object ApiPaths {
-    const val URL_AUTOCOMPLETE = "autocomplete/{value}"
+    const val URL_AUTOCOMPLETE = "autocomplete/%s"
     const val URL_AUTOCOMPLETE_SELECT_EVENT = "autocomplete/{term}/select"
     const val URL_SEARCH_SUBMIT_EVENT = "autocomplete/{term}/search"
     const val URL_SESSION_START_EVENT = "behavior"

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -12,9 +12,8 @@ import retrofit2.http.*
 
 interface ConstructorApi {
 
-    @GET(ApiPaths.URL_AUTOCOMPLETE)
-    fun getAutocompleteResults(@Path("value") value: String,
-                               @QueryMap data: Map<String, String>): Single<Result<ResponseBody>>
+    @GET
+    fun getAutocompleteResults(@Url autocompleteUrl: String): Single<Result<ResponseBody>>
 
     @GET(ApiPaths.URL_AUTOCOMPLETE_SELECT_EVENT)
     fun trackAutocompleteSelect(@Path("term") term: String,

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -12,8 +12,9 @@ import retrofit2.http.*
 
 interface ConstructorApi {
 
-    @GET
-    fun getAutocompleteResults(@Url autocompleteUrl: String): Single<Result<ResponseBody>>
+    @GET(ApiPaths.URL_AUTOCOMPLETE)
+    fun getAutocompleteResults(@Path("term") term: String,
+                               @QueryMap(encoded = true) encodedData: Map<String, String>): Single<Result<ResponseBody>>
 
     @GET(ApiPaths.URL_AUTOCOMPLETE_SELECT_EVENT)
     fun trackAutocompleteSelect(@Path("term") term: String,
@@ -52,11 +53,14 @@ interface ConstructorApi {
     fun trackPurchase(@Body purchaseRequestBody: PurchaseRequestBody,
                       @QueryMap params: Map<String, String>): Completable
 
-    @GET
-    fun getSearchResults(@Url searchUrl: String): Single<Result<ResponseBody>>
+    @GET(ApiPaths.URL_SEARCH)
+    fun getSearchResults(@Path("term") term: String,
+                         @QueryMap(encoded = true) encodedData: Map<String, String>?): Single<Result<ResponseBody>>
 
-    @GET
-    fun getBrowseResults(@Url browseUrl: String): Single<Result<ResponseBody>>
+    @GET(ApiPaths.URL_BROWSE)
+    fun getBrowseResults(@Path("filter_name") filterName: String,
+                         @Path("filter_value") filterValue: String,
+                         @QueryMap(encoded = true) encodedData: Map<String, String>): Single<Result<ResponseBody>>
 
     @POST(ApiPaths.URL_BROWSE_RESULT_CLICK_EVENT)
     fun trackBrowseResultClick(@Body browseResultClickRequestBody: BrowseResultClickRequestBody,

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -68,6 +68,21 @@ class ConstructorIoAutocompleteTest {
     }
 
     @Test
+    fun getAutocompleteResultsWithFilter() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        mockServer.enqueue(mockResponse)
+        val facet = hashMapOf("storeLocation" to listOf("CA"))
+        val observer = constructorIo.getAutocompleteResults("titanic", facet?.map { it.key to it.value }).test()
+        observer.assertComplete().assertValue {
+            var suggestions = it.get()!!.sections?.get("Search Suggestions");
+            suggestions?.isNotEmpty()!! && suggestions.size == 5
+        }
+        val request = mockServer.takeRequest()
+        val path = "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.6.0&_dt="
+        assert(request.path.startsWith(path))
+    }
+
+    @Test
     fun getAutocompleteResultsWithServerError() {
         val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
         mockServer.enqueue(mockResponse)

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -68,7 +68,7 @@ class ConstructorIoAutocompleteTest {
     }
 
     @Test
-    fun getAutocompleteResultsWithFilter() {
+    fun getAutocompleteResultsWithFacetFilter() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val facet = hashMapOf("storeLocation" to listOf("CA"))
@@ -79,6 +79,20 @@ class ConstructorIoAutocompleteTest {
         }
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.6.0&_dt="
+        assert(request.path.startsWith(path))
+    }
+
+    @Test
+    fun getAutocompleteResultsWithGroupIdFilter() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getAutocompleteResults("titanic", null, 101).test()
+        observer.assertComplete().assertValue {
+            var suggestions = it.get()!!.sections?.get("Search Suggestions");
+            suggestions?.isNotEmpty()!! && suggestions.size == 5
+        }
+        val request = mockServer.takeRequest()
+        val path = "/autocomplete/titanic?filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.6.0&_dt="
         assert(request.path.startsWith(path))
     }
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -51,6 +51,13 @@ class ConstructorIoIntegrationTest {
     }
 
     @Test
+    fun getAutocompleteResultsWithFiltersAgainstRealResponse() {
+        val facet = hashMapOf("storeLocation" to listOf("CA"))
+        val observer = constructorIo.getAutocompleteResults("pork", facet?.map { it.key to it.value }).test()
+        observer.assertComplete();
+    }
+
+    @Test
     fun trackSessionStartAgainstRealResponse() {
         val observer = constructorIo.trackSessionStartInternal().test()
         observer.assertComplete();
@@ -69,8 +76,22 @@ class ConstructorIoIntegrationTest {
     }
 
     @Test
+    fun getSearchResultsWithFiltersAgainstRealResponse() {
+        val facet = hashMapOf("storeLocation" to listOf("CA"))
+        val observer = constructorIo.getSearchResults("pork", facet?.map { it.key to it.value }).test()
+        observer.assertComplete();
+    }
+
+    @Test
     fun getBrowseResultsAgainstRealResponse() {
         val observer = constructorIo.getBrowseResults("group_ids", "544").test()
+        observer.assertComplete();
+    }
+
+    @Test
+    fun getBrowseResultsWithFiltersAgainstRealResponse() {
+        val facet = hashMapOf("storeLocation" to listOf("CA"))
+        val observer = constructorIo.getBrowseResults("group_ids", "544", facet?.map { it.key to it.value }).test()
         observer.assertComplete();
     }
 


### PR DESCRIPTION
- Add support for filtering in autocomplete requests
- Add integration tests for Browse, Search and Autocomplete
- Autocomplete requests only accepts 1 filter at the moment and returns an error if more than 1 is supplied