### PR TITLE
[CSL 698] Add Section Param to Result Methods

### DIFF
--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -159,7 +159,7 @@ object ConstructorIo {
      * @param sectionName the section the results will come from defaults to "Products"
      * @param hiddenFields show fields that are hidden by default
      */
-    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, hiddenFields: List<String>? = null, sectionName: String? = null): Observable<ConstructorData<SearchResponse>> {
+    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<SearchResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }
@@ -191,7 +191,7 @@ object ConstructorIo {
      * @param sectionName the section the results will come from defaults to "Products"
      * @param hiddenFields show fields that are hidden by default
      */
-    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, hiddenFields: List<String>? = null, sectionName: String? = null): Observable<ConstructorData<BrowseResponse>> {
+    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<BrowseResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -156,15 +156,17 @@ object ConstructorIo {
      * @param groupId category facet used to refine results
      * @param sortBy the sort method for results
      * @param sortOrder the sort order for results
+     * @param sectionName the section the selection will come from, i.e. "Products"
      * @param hiddenFields show fields that are hidden by default
      */
-    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<SearchResponse>> {
+    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<SearchResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }
         perPage?.let { encodedParams.add(Constants.QueryConstants.PER_PAGE.urlEncode() to perPage.toString().urlEncode()) }
         sortBy?.let { encodedParams.add(Constants.QueryConstants.SORT_BY.urlEncode() to it.urlEncode()) }
         sortOrder?.let { encodedParams.add(Constants.QueryConstants.SORT_ORDER.urlEncode() to it.urlEncode()) }
+        sectionName?.let { encodedParams.add(Constants.QueryConstants.SECTION.urlEncode() to sectionName.toString().urlEncode()) }
         facets?.forEach { facet ->
             facet.second.forEach {
                 encodedParams.add(Constants.QueryConstants.FILTER_FACET.format(facet.first).urlEncode() to it.urlEncode())
@@ -186,15 +188,17 @@ object ConstructorIo {
      * @param groupId category facet used to refine results
      * @param sortBy the sort method for results
      * @param sortOrder the sort order for results
+     * @param sectionName the section the selection will come from, i.e. "Products"
      * @param hiddenFields show fields that are hidden by default
      */
-    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<BrowseResponse>> {
+    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<BrowseResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }
         perPage?.let { encodedParams.add(Constants.QueryConstants.PER_PAGE.urlEncode() to perPage.toString().urlEncode()) }
         sortBy?.let { encodedParams.add(Constants.QueryConstants.SORT_BY.urlEncode() to it.urlEncode()) }
         sortOrder?.let { encodedParams.add(Constants.QueryConstants.SORT_ORDER.urlEncode() to it.urlEncode()) }
+        sectionName?.let { encodedParams.add(Constants.QueryConstants.SECTION.urlEncode() to sectionName.toString().urlEncode()) }
         facets?.forEach { facet ->
             facet.second.forEach {
                 encodedParams.add(Constants.QueryConstants.FILTER_FACET.format(facet.first).urlEncode() to it.urlEncode())

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -156,10 +156,10 @@ object ConstructorIo {
      * @param groupId category facet used to refine results
      * @param sortBy the sort method for results
      * @param sortOrder the sort order for results
-     * @param sectionName the section the selection will come from, i.e. "Products"
+     * @param sectionName the section the results will come from defaults to "Products"
      * @param hiddenFields show fields that are hidden by default
      */
-    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<SearchResponse>> {
+    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, hiddenFields: List<String>? = null, sectionName: String? = null): Observable<ConstructorData<SearchResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }
@@ -188,10 +188,10 @@ object ConstructorIo {
      * @param groupId category facet used to refine results
      * @param sortBy the sort method for results
      * @param sortOrder the sort order for results
-     * @param sectionName the section the selection will come from, i.e. "Products"
+     * @param sectionName the section the results will come from defaults to "Products"
      * @param hiddenFields show fields that are hidden by default
      */
-    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null): Observable<ConstructorData<BrowseResponse>> {
+    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, hiddenFields: List<String>? = null, sectionName: String? = null): Observable<ConstructorData<BrowseResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -122,7 +122,7 @@ class ConstructorIoBrowseTest {
     fun getBrowseResultsWithSection() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, "Sold Out").test()
+        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, "Sold Out").test()
         val request = mockServer.takeRequest()
         val path = "/browse/group_id/Beverages?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt"
         assert(request.path!!.startsWith(path))
@@ -132,7 +132,7 @@ class ConstructorIoBrowseTest {
     fun getBrowseResultsWithHiddenFields() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2"), null).test()
         val request = mockServer.takeRequest()
         val path = "/browse/group_id/Beverages?hidden_fields=hiddenField1&hidden_fields=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt"
         assert(request.path!!.startsWith(path))

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -122,7 +122,7 @@ class ConstructorIoBrowseTest {
     fun getBrowseResultsWithSection() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, "Sold Out").test()
+        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, "Sold Out").test()
         val request = mockServer.takeRequest()
         val path = "/browse/group_id/Beverages?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt"
         assert(request.path!!.startsWith(path))
@@ -132,7 +132,7 @@ class ConstructorIoBrowseTest {
     fun getBrowseResultsWithHiddenFields() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2"), null).test()
+        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
         val request = mockServer.takeRequest()
         val path = "/browse/group_id/Beverages?hidden_fields=hiddenField1&hidden_fields=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt"
         assert(request.path!!.startsWith(path))

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -119,10 +119,20 @@ class ConstructorIoBrowseTest {
     }
 
     @Test
+    fun getBrowseResultsWithSection() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, "Sold Out").test()
+        val request = mockServer.takeRequest()
+        val path = "/browse/group_id/Beverages?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt"
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun getBrowseResultsWithHiddenFields() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
         val request = mockServer.takeRequest()
         val path = "/browse/group_id/Beverages?hidden_fields=hiddenField1&hidden_fields=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt"
         assert(request.path!!.startsWith(path))

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -137,7 +137,7 @@ class ConstructorIoSearchTest {
     fun getSearchResultsWithSection() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, "Sold Out").test()
+        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, "Sold Out").test()
         val request = mockServer.takeRequest()
         val path = "/search/bbq?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt="
         assert(request.path!!.startsWith(path))
@@ -147,7 +147,7 @@ class ConstructorIoSearchTest {
     fun getSearchResultsWithHiddenFields() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, listOf("hiddenField1", "hiddenField2"), null).test()
+        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
         val request = mockServer.takeRequest()
         val path = "/search/bbq?hidden_fields=hiddenField1&hidden_fields=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt="
         assert(request.path!!.startsWith(path))

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -137,7 +137,7 @@ class ConstructorIoSearchTest {
     fun getSearchResultsWithSection() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, "Sold Out").test()
+        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, "Sold Out").test()
         val request = mockServer.takeRequest()
         val path = "/search/bbq?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt="
         assert(request.path!!.startsWith(path))
@@ -147,7 +147,7 @@ class ConstructorIoSearchTest {
     fun getSearchResultsWithHiddenFields() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, listOf("hiddenField1", "hiddenField2"), null).test()
         val request = mockServer.takeRequest()
         val path = "/search/bbq?hidden_fields=hiddenField1&hidden_fields=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt="
         assert(request.path!!.startsWith(path))

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -134,10 +134,20 @@ class ConstructorIoSearchTest {
     }
 
     @Test
+    fun getSearchResultsWithSection() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, "Sold Out").test()
+        val request = mockServer.takeRequest()
+        val path = "/search/bbq?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun getSearchResultsWithHiddenFields() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
         val request = mockServer.takeRequest()
         val path = "/search/bbq?hidden_fields=hiddenField1&hidden_fields=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.12.0&_dt="
         assert(request.path!!.startsWith(path))


### PR DESCRIPTION
- Enable param for search and browse result methods to allow access to non-Product sections (i.e. "Sold Out")