### PR TITLE
Fix encoding issue

### DIFF
--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -157,7 +157,7 @@ object ConstructorIo {
         hiddenFields?.forEach { hiddenField ->
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FIELD).urlEncode() to hiddenField.urlEncode())
         }
-        return dataManager.getAutocompleteResults(term, encodedParams = encodedParams.toTypedArray())
+        return dataManager.getAutocompleteResults(term.urlEncode(), encodedParams = encodedParams.toTypedArray())
     }
 
     /**
@@ -204,7 +204,7 @@ object ConstructorIo {
         hiddenFacets?.forEach { hiddenFacet ->
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
         }
-        return dataManager.getSearchResults(term, encodedParams = encodedParams.toTypedArray())
+        return dataManager.getSearchResults(term.urlEncode(), encodedParams = encodedParams.toTypedArray())
     }
 
     /**

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -146,4 +146,14 @@ class ConstructorIoAutocompleteTest {
         val path = "/autocomplete/bbq?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.0&_dt="
         assert(request.path!!.startsWith(path))
     }
+
+    @Test
+    fun getAutocompleteResultsWithProperUrlEncoding() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getAutocompleteResults("2% cheese").test()
+        val request = mockServer.takeRequest()
+        val path = "/autocomplete/2%25%20cheese?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.0&_dt="
+        assert(request.path!!.startsWith(path))
+    }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -174,4 +174,14 @@ class ConstructorIoSearchTest {
         val path = "/search/bbq?fmt_options%5Bhidden_facets%5D=Brand&fmt_options%5Bhidden_facets%5D=price_US&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.0&_dt="
         assert(request.path!!.startsWith(path))
     }
+
+    @Test
+    fun getSearchResultsWithProperUrlEncoding() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getSearchResults("2% cheese").test()
+        val request = mockServer.takeRequest()
+        val path = "/search/2%25%20cheese?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.0&_dt="
+        assert(request.path!!.startsWith(path))
+    }
 }


### PR DESCRIPTION
- Special characters weren't being encoded
  - "2% cheese" came out as "2%%20cheese" as opposed to "2%25%20cheese"