### PR TITLE
[CSL 1161] Android Request Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,35 @@ ConstructorIo.getAutocompleteResults(query, selectedFacet?.map { it.key to it.va
 }
 ```
 
+### Alternative using Request Builder or DSL
+```kotlin
+// Creating a request using Request Builder
+val autocompleteRequest = AutocompleteRequest.Builder("potato")
+  .setNumResultsPerSection(mapOf(
+    "Products" to 6,
+    "Search Suggestions" to 8
+  ))
+  .setFilters(mapOf(
+    "group_id" to listOf("G123"),
+    "availability" to listOf("US", "CA")
+  ))
+  .build()
+
+// Creating a request using DSL
+val autocompleteRequest = AutocompleteRequest.build("potato") {
+  numResultsPerSection = mapOf(
+    "Products" to 6,
+    "Search Suggestions" to 8
+  )
+  filters = mapOf(
+    "group_id" to listOf("G123"),
+    "availability" to listOf("US", "CA")
+  )
+}
+
+constructorIo.getAutocompleteResults(autocompleteRequest)
+```
+
 ## 5. Request Search Results
 
 ```kotlin
@@ -73,6 +102,29 @@ ConstructorIo.getSearchResults(query, selectedFacets?.map { it.key to it.value }
     }
   }
 }
+```
+
+### Alternative using Request Builder or DSL
+```kotlin
+// Creating a request using Request Builder
+val request = SearchRequest.Builder("potato")
+  .setFilters(mapOf(
+    "group_id" to listOf("G123"),
+    "Brand" to listOf("Kings Hawaiin")
+  ))
+  .setHiddenFields(listOf("hidden_field_1", "hidden_field_2"))
+  .build()
+
+// Creating a request using DSL
+val request = SearchRequest.build("potato") {
+  filters = mapOf(
+    "group_id" to listOf("G123"),
+    "Brand" to listOf("Kings Hawaiin")
+  )
+  hiddenFields = listOf("hidden_field_1", "hidden_field_2")
+}
+
+ConstructorIo.getSearchResults(request)
 ```
 
 ## 6. Request Browse Results
@@ -96,6 +148,31 @@ ConstructorIo.getBrowseResults(filterName, filterValue, selectedFacets?.map { it
 }
 ```
 
+### Alternative using Request Builder or DSL
+```kotlin
+// Creating a request using Request Builder
+val browseRequest = BrowseRequest.Builder("group_id", "123")
+  .setFilters(mapOf(
+    "group_id" to listOf("G1234"),
+    "Brand" to listOf("Cnstrc")
+    "Color" to listOf("Red", "Blue")
+  ))
+  .setHiddenFacets(listOf("hidden_facet_1", "hidden_facet_2"))
+  .build()
+
+// Creating a request using DSL
+val browseRequest = BrowseRequest.build("group_id", "123") {
+  filters = mapOf(
+    "group_id" to listOf("G1234"),
+    "Brand" to listOf("Cnstrc")
+    "Color" to listOf("Red", "Blue")
+  )
+  hiddenFacets = listOf("hidden_facet_1", "hidden_facet_2")
+}
+
+ConstructorIo.getBrowseResults(browseRequest)
+```
+
 ## 7. Request Recommendation Results
 
 ```kotlin
@@ -113,6 +190,21 @@ ConstructorIo.getRecommendationResults(podId, selectedFacets?.map { it.key to it
     }
   }
 }
+```
+
+### Alternative using Request Builder or DSL
+```kotlin
+// Creating a request using Request Builder
+val recommendationsRequest = RecommendationsRequest.Builder("product_detail_page")
+  .setItemIds(listOf("item_id_123"))
+  .build()
+
+// Creating a request using DSL
+val recommendationsRequest = RecommendationsRequest.build("product_detail_page") {
+  itemIds = listOf("item_id_123")
+}
+
+ConstructorIo.getRecommendationResults(recommendationsRequest)
 ```
 
 ## 8. Instrument Behavioral Events

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ConstructorIo.getSearchResults(query, selectedFacets?.map { it.key to it.value }
 ### Alternative using Request Builder or DSL
 ```kotlin
 // Creating a request using Request Builder
-val request = SearchRequest.Builder("potato")
+val searchRequest = SearchRequest.Builder("potato")
   .setFilters(mapOf(
     "group_id" to listOf("G123"),
     "Brand" to listOf("Kings Hawaiin")
@@ -116,7 +116,7 @@ val request = SearchRequest.Builder("potato")
   .build()
 
 // Creating a request using DSL
-val request = SearchRequest.build("potato") {
+val searchRequest = SearchRequest.build("potato") {
   filters = mapOf(
     "group_id" to listOf("G123"),
     "Brand" to listOf("Kings Hawaiin")
@@ -124,7 +124,7 @@ val request = SearchRequest.build("potato") {
   hiddenFields = listOf("hidden_field_1", "hidden_field_2")
 }
 
-ConstructorIo.getSearchResults(request)
+ConstructorIo.getSearchResults(searchRequest)
 ```
 
 ## 6. Request Browse Results

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -173,12 +173,12 @@ object ConstructorIo {
      *      "Brand" to listOf("Cnstrc")
      *      "Color" to listOf("Red", "Blue")
      * )
-     * val query = AutocompleteRequest.Builder("Dav")
+     * val request = AutocompleteRequest.Builder("Dav")
      *      .setFilters(filters)
-     *      .setHiddenFields(listOf("hidden_field_1", "hidden_field_2")
+     *      .setHiddenFields(listOf("hidden_field_1", "hidden_field_2"))
      *      .build()
      *
-     * ConstructorIo.getAutocompleteResults(query)
+     * ConstructorIo.getAutocompleteResults(request)
      *      .subscribeOn(Schedulers.io())
      *      .observeOn(AndroidSchedulers.mainThread())
      *      .subscribe {
@@ -273,12 +273,12 @@ object ConstructorIo {
      *      "Brand" to listOf("Cnstrc")
      *      "Color" to listOf("Red", "Blue")
      * )
-     * val query = SearchRequest.Builder("Dav")
+     * val request = SearchRequest.Builder("Dav")
      *      .setFilters(filters)
-     *      .setHiddenFacets(listOf("hidden_facet_1", "hidden_facet_2")
+     *      .setHiddenFacets(listOf("hidden_facet_1", "hidden_facet_2"))
      *      .build()
      *
-     * ConstructorIo.getSearchResults(query)
+     * ConstructorIo.getSearchResults(request)
      *      .subscribeOn(Schedulers.io())
      *      .observeOn(AndroidSchedulers.mainThread())
      *      .subscribe {
@@ -378,12 +378,12 @@ object ConstructorIo {
      *      "Brand" to listOf("Cnstrc")
      *      "Color" to listOf("Red", "Blue")
      * )
-     * val query = BrowseRequest.Builder("group_id", "123")
+     * val request = BrowseRequest.Builder("group_id", "123")
      *      .setFilters(filters)
-     *      .setHiddenFacets(listOf("hidden_facet_1", "hidden_facet_2")
+     *      .setHiddenFacets(listOf("hidden_facet_1", "hidden_facet_2"))
      *      .build()
      *
-     * ConstructorIo.getBrowseResults(query)
+     * ConstructorIo.getBrowseResults(request)
      *      .subscribeOn(Schedulers.io())
      *      .observeOn(AndroidSchedulers.mainThread())
      *      .subscribe {
@@ -788,11 +788,11 @@ object ConstructorIo {
      * Returns a list of recommendation results for the specified pod
      * ## Example
      * ```
-     * val query = BrowseRequest.Builder("product_detail_page")
+     * val request = RecommendationsRequest.Builder("product_detail_page")
      *      .setItemIds(listOf("item_id_123"))
      *      .build()
      *
-     * ConstructorIo.getRecommendationResults(query)
+     * ConstructorIo.getRecommendationResults(request)
      *      .subscribeOn(Schedulers.io())
      *      .observeOn(AndroidSchedulers.mainThread())
      *      .subscribe {

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -6,6 +6,7 @@ import io.constructor.BuildConfig
 import io.constructor.data.ConstructorData
 import io.constructor.data.DataManager
 import io.constructor.data.builder.AutocompleteRequest
+import io.constructor.data.builder.BrowseRequest
 import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
@@ -195,7 +196,7 @@ object ConstructorIo {
         request.filters?.forEach { filter ->
             if (filter.key == "group_id") {
                 filter.value.forEach {
-                    encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString())
+                    encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.urlEncode())
                 }
             } else {
                 filter.value.forEach {
@@ -300,7 +301,7 @@ object ConstructorIo {
         request.filters?.forEach { filter ->
             if (filter.key == "group_id") {
                 filter.value.forEach {
-                    encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString())
+                    encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.urlEncode())
                 }
             } else {
                 filter.value.forEach {
@@ -365,6 +366,62 @@ object ConstructorIo {
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
         }
         return dataManager.getBrowseResults(filterName, filterValue, encodedParams = encodedParams.toTypedArray())
+    }
+
+    /**
+     * Returns a list of search results including filters, categories, sort options, etc.
+     * ## Example
+     * ```
+     * val filters = mapOf(
+     *      "group_id" to listOf("G1234"),
+     *      "Brand" to listOf("Cnstrc")
+     *      "Color" to listOf("Red", "Blue")
+     * )
+     * val query = BrowseRequest.Builder("group_id", "123")
+     *      .setFilters(filters)
+     *      .setHiddenFacets(listOf("hidden_facet_1", "hidden_facet_2")
+     *      .build()
+     *
+     * ConstructorIo.getBrowseResults(query)
+     *      .subscribeOn(Schedulers.io())
+     *      .observeOn(AndroidSchedulers.mainThread())
+     *      .subscribe {
+     *          it.onValue {
+     *              it?.let {
+     *                  view.renderData(it)
+     *              }
+     *          }
+     *      }
+     * ```
+     * @param request the search request object
+     */
+    fun getBrowseResults(request: BrowseRequest): Observable<ConstructorData<BrowseResponse>> {
+        val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
+
+        request.page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to it.toString().urlEncode()) }
+        request.perPage?.let { encodedParams.add(Constants.QueryConstants.PER_PAGE.urlEncode() to it.toString().urlEncode()) }
+        request.sortBy?.let { encodedParams.add(Constants.QueryConstants.SORT_BY.urlEncode() to it.urlEncode()) }
+        request.sortOrder?.let { encodedParams.add(Constants.QueryConstants.SORT_ORDER.urlEncode() to it.urlEncode()) }
+        request.section?.let { encodedParams.add(Constants.QueryConstants.SECTION.urlEncode() to it.urlEncode()) }
+        request.filters?.forEach { filter ->
+            if (filter.key == "group_id") {
+                filter.value.forEach {
+                    encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.urlEncode())
+                }
+            } else {
+                filter.value.forEach {
+                    encodedParams.add(Constants.QueryConstants.FILTER_FACET.format(filter.key).urlEncode() to it.urlEncode())
+                }
+            }
+        }
+        request.hiddenFields?.forEach { hiddenField ->
+            encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FIELD).urlEncode() to hiddenField.urlEncode())
+        }
+        request.hiddenFacets?.forEach { hiddenFacet ->
+            encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
+        }
+
+        return dataManager.getBrowseResults(request.filterName, request.filterValue, encodedParams = encodedParams.toTypedArray())
     }
 
     /**

--- a/library/src/main/java/io/constructor/data/builder/AutocompleteRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/AutocompleteRequest.kt
@@ -12,16 +12,16 @@ class AutocompleteRequest (
     private constructor(builder: Builder) : this(builder.term, builder.filters, builder.numResultsPerSection, builder.hiddenFields)
 
     companion object {
-        inline fun build(block: Builder.() -> Unit) = Builder().apply(block).build()
+        inline fun build(term: String, block: Builder.() -> Unit = {}) = Builder(term).apply(block).build()
     }
 
-    class Builder {
-        lateinit var term: String
+    class Builder(
+        val term: String
+    ) {
         var filters: Map<String, List<String>>? = null
         var numResultsPerSection: Map<String, Int>? = null
         var hiddenFields: List<String>? = null
 
-        fun setTerm(term: String): Builder = apply { this.term = term }
         fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
         fun setNumResultsPerSection(numResultsPerSection: Map<String, Int>): Builder = apply { this.numResultsPerSection = numResultsPerSection }
         fun setHiddenFields(hiddenFields: List<String>): Builder = apply { this.hiddenFields = hiddenFields }

--- a/library/src/main/java/io/constructor/data/builder/AutocompleteRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/AutocompleteRequest.kt
@@ -9,7 +9,12 @@ class AutocompleteRequest (
     val numResultsPerSection: Map<String, Int>? = null,
     val hiddenFields: List<String>? = null,
 ) {
-    private constructor(builder: Builder) : this(builder.term, builder.filters, builder.numResultsPerSection, builder.hiddenFields)
+    private constructor(builder: Builder) : this(
+        builder.term,
+        builder.filters,
+        builder.numResultsPerSection,
+        builder.hiddenFields
+    )
 
     companion object {
         inline fun build(term: String, block: Builder.() -> Unit = {}) = Builder(term).apply(block).build()

--- a/library/src/main/java/io/constructor/data/builder/AutocompleteRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/AutocompleteRequest.kt
@@ -1,0 +1,30 @@
+package io.constructor.data.builder
+
+/**
+ * Create an Autocomplete request object utilizing a builder
+ */
+class AutocompleteRequest (
+    val term: String,
+    val filters: Map<String, List<String>>? = null,
+    val numResultsPerSection: Map<String, Int>? = null,
+    val hiddenFields: List<String>? = null,
+) {
+    private constructor(builder: Builder) : this(builder.term, builder.filters, builder.numResultsPerSection, builder.hiddenFields)
+
+    companion object {
+        inline fun build(block: Builder.() -> Unit) = Builder().apply(block).build()
+    }
+
+    class Builder {
+        lateinit var term: String
+        var filters: Map<String, List<String>>? = null
+        var numResultsPerSection: Map<String, Int>? = null
+        var hiddenFields: List<String>? = null
+
+        fun setTerm(term: String): Builder = apply { this.term = term }
+        fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
+        fun setNumResultsPerSection(numResultsPerSection: Map<String, Int>): Builder = apply { this.numResultsPerSection = numResultsPerSection }
+        fun setHiddenFields(hiddenFields: List<String>): Builder = apply { this.hiddenFields = hiddenFields }
+        fun build(): AutocompleteRequest = AutocompleteRequest(this)
+    }
+}

--- a/library/src/main/java/io/constructor/data/builder/BrowseRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/BrowseRequest.kt
@@ -1,0 +1,58 @@
+package io.constructor.data.builder
+
+/**
+ * Create a Browse request object utilizing a builder
+ */
+class BrowseRequest (
+    val filterName: String,
+    val filterValue: String,
+    val filters: Map<String, List<String>>? = null,
+    val page: Int? = null,
+    val perPage: Int? = null,
+    val sortBy: String? = null,
+    val sortOrder: String? = null,
+    val section: String? = null,
+    val hiddenFields: List<String>? = null,
+    val hiddenFacets: List<String>? = null,
+) {
+    private constructor(builder: Builder) : this(
+        builder.filterName,
+        builder.filterValue,
+        builder.filters,
+        builder.page,
+        builder.perPage,
+        builder.sortBy,
+        builder.sortOrder,
+        builder.section,
+        builder.hiddenFields,
+        builder.hiddenFacets,
+    )
+
+    companion object {
+        inline fun build(filterName: String, filterValue: String, block: Builder.() -> Unit = {}) = Builder(filterName, filterValue).apply(block).build()
+    }
+
+    class Builder(
+        val filterName: String,
+        val filterValue: String
+    ) {
+        var filters: Map<String, List<String>>? = null
+        var page: Int? = null
+        var perPage: Int? = null
+        var sortBy: String? = null
+        var sortOrder: String? = null
+        var section: String? = null
+        var hiddenFields: List<String>? = null
+        var hiddenFacets: List<String>? = null
+
+        fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
+        fun setPage(page: Int): Builder = apply { this.page = page }
+        fun setPerPage(perPage: Int): Builder = apply { this.perPage = perPage }
+        fun setSortBy(sortBy: String): Builder = apply { this.sortBy = sortBy }
+        fun setSortOrder(sortOrder: String): Builder = apply { this.sortOrder = sortOrder }
+        fun setSection(section: String): Builder = apply { this.section = section }
+        fun setHiddenFields(hiddenFields: List<String>): Builder = apply { this.hiddenFields = hiddenFields }
+        fun setHiddenFacets(hiddenFacets: List<String>): Builder = apply { this.hiddenFacets = hiddenFacets }
+        fun build(): BrowseRequest = BrowseRequest(this)
+    }
+}

--- a/library/src/main/java/io/constructor/data/builder/RecommendationsRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/RecommendationsRequest.kt
@@ -1,0 +1,43 @@
+package io.constructor.data.builder
+
+/**
+ * Create a Recommendations request object utilizing a builder
+ */
+class RecommendationsRequest (
+    val podId: String,
+    val filters: Map<String, List<String>>? = null,
+    val itemIds: List<String>? = null,
+    val term: String? = null,
+    val numResults: Int? = null,
+    val section: String? = null,
+) {
+    private constructor(builder: Builder) : this(
+        builder.podId,
+        builder.filters,
+        builder.itemIds,
+        builder.term,
+        builder.numResults,
+        builder.section,
+    )
+
+    companion object {
+        inline fun build(term: String, block: Builder.() -> Unit = {}) = Builder(term).apply(block).build()
+    }
+
+    class Builder(
+        val podId: String
+    ) {
+        var filters: Map<String, List<String>>? = null
+        var numResults: Int? = null
+        var itemIds: List<String>? = null
+        var term: String? = null
+        var section: String? = null
+
+        fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
+        fun setItemIds(itemIds: List<String>): Builder = apply { this.itemIds = itemIds }
+        fun setTerm(term: String): Builder = apply { this.term = term }
+        fun setNumResults(numResults: Int): Builder = apply { this.numResults = numResults }
+        fun setSection(section: String): Builder = apply { this.section = section }
+        fun build(): RecommendationsRequest = RecommendationsRequest(this)
+    }
+}

--- a/library/src/main/java/io/constructor/data/builder/SearchRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/SearchRequest.kt
@@ -1,0 +1,55 @@
+package io.constructor.data.builder
+
+/**
+ * Create a Search request object utilizing a builder
+ */
+class SearchRequest (
+    val term: String,
+    val filters: Map<String, List<String>>? = null,
+    val page: Int? = null,
+    val perPage: Int? = null,
+    val sortBy: String? = null,
+    val sortOrder: String? = null,
+    val section: String? = null,
+    val hiddenFields: List<String>? = null,
+    val hiddenFacets: List<String>? = null,
+) {
+    private constructor(builder: Builder) : this(
+        builder.term,
+        builder.filters,
+        builder.page,
+        builder.perPage,
+        builder.sortBy,
+        builder.sortOrder,
+        builder.section,
+        builder.hiddenFields,
+        builder.hiddenFacets,
+    )
+
+    companion object {
+        inline fun build(term: String, block: Builder.() -> Unit = {}) = Builder(term).apply(block).build()
+    }
+
+    class Builder(
+        val term: String
+    ) {
+        var filters: Map<String, List<String>>? = null
+        var page: Int? = null
+        var perPage: Int? = null
+        var sortBy: String? = null
+        var sortOrder: String? = null
+        var section: String? = null
+        var hiddenFields: List<String>? = null
+        var hiddenFacets: List<String>? = null
+
+        fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
+        fun setPage(page: Int): Builder = apply { this.page = page }
+        fun setPerPage(perPage: Int): Builder = apply { this.perPage = perPage }
+        fun setSortBy(sortBy: String): Builder = apply { this.sortBy = sortBy }
+        fun setSortOrder(sortOrder: String): Builder = apply { this.sortOrder = sortOrder }
+        fun setSection(section: String): Builder = apply { this.section = section }
+        fun setHiddenFields(hiddenFields: List<String>): Builder = apply { this.hiddenFields = hiddenFields }
+        fun setHiddenFacets(hiddenFacets: List<String>): Builder = apply { this.hiddenFacets = hiddenFacets }
+        fun build(): SearchRequest = SearchRequest(this)
+    }
+}

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -1,6 +1,7 @@
 package io.constructor.core
 
 import android.content.Context
+import io.constructor.data.builder.AutocompleteRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.test.createTestDataManager
@@ -154,6 +155,28 @@ class ConstructorIoAutocompleteTest {
         val observer = constructorIo.getAutocompleteResults("2% cheese").test()
         val request = mockServer.takeRequest()
         val path = "/autocomplete/2%25%20cheese?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.2&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
+    fun getAutocompleteResultsWithFiltersUsingBuilder() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        mockServer.enqueue(mockResponse)
+        val filters = mapOf(
+            "storeLocation" to listOf("CA"),
+            "group_id" to listOf("101")
+        )
+        val autocompleteRequest = AutocompleteRequest.Builder("titanic")
+            .setFilters(filters)
+            .build()
+        val observer = constructorIo.getAutocompleteResults(autocompleteRequest).test()
+        observer.assertComplete().assertValue {
+            var suggestions = it.get()!!.sections?.get("Search Suggestions");
+            suggestions?.isNotEmpty()!! && suggestions.size == 5
+        }
+        val request = mockServer.takeRequest()
+        System.out.println(request.path)
+        val path = "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -175,8 +175,29 @@ class ConstructorIoAutocompleteTest {
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        System.out.println(request.path)
         val path = "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.1&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+
+    @Test
+    fun getAutocompleteResultsWithNumResultsPerSectionUsingBuilder() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        mockServer.enqueue(mockResponse)
+        val numResultsPerSection = mapOf(
+            "Products" to 5,
+            "Search Suggestions" to 10,
+        )
+        val autocompleteRequest = AutocompleteRequest.Builder("titanic")
+                .setNumResultsPerSection(numResultsPerSection)
+                .build()
+        val observer = constructorIo.getAutocompleteResults(autocompleteRequest).test()
+        observer.assertComplete().assertValue {
+            var suggestions = it.get()!!.sections?.get("Search Suggestions");
+            suggestions?.isNotEmpty()!! && suggestions.size == 5
+        }
+        val request = mockServer.takeRequest()
+        val path = "/autocomplete/titanic?num_results_Products=5&num_results_Search%20Suggestions=10&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -1,6 +1,8 @@
 package io.constructor.core
 
 import android.content.Context
+import io.constructor.data.builder.AutocompleteRequest
+import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.test.createTestDataManager
@@ -268,6 +270,31 @@ class ConstructorIoIntegrationTest {
             it.get()?.response?.facets!!.isNotEmpty()
             it.get()?.response?.collection?.id == "test-collection"
             it.get()?.response?.collection?.displayName == "test collection"
+        }
+    }
+
+    @Test
+    fun getAutocompleteResultsAgainstRealResponseUsingRequestBuilder() {
+        val request = AutocompleteRequest.Builder("pork").build()
+        val observer = constructorIo.getAutocompleteResults(request).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.sections!!.isNotEmpty()
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
+    fun getSearchResultAgainstRealResponseUsingRequestBuilder() {
+        val request = SearchRequest.Builder("pork").build()
+        val observer = constructorIo.getSearchResults(request).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.results!!.isNotEmpty()
+            it.get()?.response?.facets!!.isNotEmpty()
+            it.get()?.response?.groups!!.isNotEmpty()
+            it.get()?.response?.filterSortOptions!!.isNotEmpty()
+            it.get()?.response?.resultCount!! > 0
         }
         Thread.sleep(timeBetweenTests)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -2,6 +2,7 @@ package io.constructor.core
 
 import android.content.Context
 import io.constructor.data.builder.AutocompleteRequest
+import io.constructor.data.builder.BrowseRequest
 import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
@@ -288,6 +289,21 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultAgainstRealResponseUsingRequestBuilder() {
         val request = SearchRequest.Builder("pork").build()
         val observer = constructorIo.getSearchResults(request).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.results!!.isNotEmpty()
+            it.get()?.response?.facets!!.isNotEmpty()
+            it.get()?.response?.groups!!.isNotEmpty()
+            it.get()?.response?.filterSortOptions!!.isNotEmpty()
+            it.get()?.response?.resultCount!! > 0
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
+    fun getBrowseResultAgainstRealResponseUsingRequestBuilder() {
+        val request = BrowseRequest.Builder("group_id", "431").build()
+        val observer = constructorIo.getBrowseResults(request).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.response?.results!!.isNotEmpty()

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -3,6 +3,7 @@ package io.constructor.core
 import android.content.Context
 import io.constructor.data.builder.AutocompleteRequest
 import io.constructor.data.builder.BrowseRequest
+import io.constructor.data.builder.RecommendationsRequest
 import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
@@ -178,8 +179,8 @@ class ConstructorIoIntegrationTest {
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.response?.pod !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
+            it.get()?.response?.results !== null
+            it.get()?.response?.resultCount!! >= 0
         }
         Thread.sleep(timeBetweenTests)
     }
@@ -311,6 +312,19 @@ class ConstructorIoIntegrationTest {
             it.get()?.response?.groups!!.isNotEmpty()
             it.get()?.response?.filterSortOptions!!.isNotEmpty()
             it.get()?.response?.resultCount!! > 0
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
+    fun getRecommendationResultsAgainstRealResponseUsingRequestBuilder() {
+        val request = RecommendationsRequest.Builder("pdp5").build()
+        val observer = constructorIo.getRecommendationResults(request).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.pod !== null
+            it.get()?.response?.results !== null
+            it.get()?.response?.resultCount!! >= 0
         }
         Thread.sleep(timeBetweenTests)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
@@ -114,7 +114,7 @@ class ConstructorIoRecommendationsTest {
     }
 
     @Test
-    fun getRecommendationResultsWithBuilder() {
+    fun getRecommendationResultsUsingBuilder() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("recommendation_response.json"))
         mockServer.enqueue(mockResponse)
         val recommendationsRequest = RecommendationsRequest.Builder("titanic").build()
@@ -129,6 +129,28 @@ class ConstructorIoRecommendationsTest {
         }
         val request = mockServer.takeRequest()
         val path = "/recommendations/v1/pods/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.1&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
+    fun getRecommendationResultsWithMultipleItemIdsUsingBuilder() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("recommendation_response.json"))
+        mockServer.enqueue(mockResponse)
+        val recommendationsRequest = RecommendationsRequest.Builder("titanic")
+            .setItemIds(listOf("item_id_1", "item_id_2"))
+            .build()
+        val observer = constructorIo.getRecommendationResults(recommendationsRequest).test()
+        observer.assertComplete().assertValue {
+            it.get()!!.response?.results!!.size == 24
+            it.get()!!.response?.results!![0].value == "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz."
+            it.get()!!.response?.results!![0].data.id == "960189161"
+            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png"
+            it.get()!!.response?.results!![0].data.metadata?.get("price") == 1.11
+            it.get()!!.response?.resultCount == 225
+        }
+        val request = mockServer.takeRequest()
+        System.out.println(request.path)
+        val path = "/recommendations/v1/pods/titanic?item_id=item_id_1&item_id=item_id_2&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
@@ -1,6 +1,7 @@
 package io.constructor.core
 
 import android.content.Context
+import io.constructor.data.builder.RecommendationsRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.test.createTestDataManager
@@ -109,6 +110,25 @@ class ConstructorIoRecommendationsTest {
         }
         val request = mockServer.takeRequest()
         val path = "/recommendations/v1/pods/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.2&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
+    fun getRecommendationResultsWithBuilder() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("recommendation_response.json"))
+        mockServer.enqueue(mockResponse)
+        val recommendationsRequest = RecommendationsRequest.Builder("titanic").build()
+        val observer = constructorIo.getRecommendationResults(recommendationsRequest).test()
+        observer.assertComplete().assertValue {
+            it.get()!!.response?.results!!.size == 24
+            it.get()!!.response?.results!![0].value == "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz."
+            it.get()!!.response?.results!![0].data.id == "960189161"
+            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png"
+            it.get()!!.response?.results!![0].data.metadata?.get("price") == 1.11
+            it.get()!!.response?.resultCount == 225
+        }
+        val request = mockServer.takeRequest()
+        val path = "/recommendations/v1/pods/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.14.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -1,6 +1,8 @@
 package io.constructor.core
 
 import android.content.Context
+import io.constructor.data.builder.BrowseRequest
+import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.test.createTestDataManager
@@ -167,6 +169,23 @@ class ConstructorIoBrowseTest {
         val observer = constructorIo.getBrowseResults("collection_id", "test-collection").test()
         val request = mockServer.takeRequest()
         val path = "/browse/collection_id/test-collection?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.2&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
+    fun getBrowseResultsWithFiltersUsingBuilder() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        mockServer.enqueue(mockResponse)
+        val filters = mapOf(
+            "Brand" to listOf("Signature Farms", "Del Monte"),
+            "Nutrition" to listOf("Organic")
+        )
+        val browseRequest = BrowseRequest.Builder("group_id", "Beverages")
+                .setFilters(filters)
+                .build()
+        val observer = constructorIo.getBrowseResults(browseRequest).test()
+        val request = mockServer.takeRequest()
+        val path = "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -1,6 +1,7 @@
 package io.constructor.core
 
 import android.content.Context
+import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.test.createTestDataManager
@@ -182,6 +183,23 @@ class ConstructorIoSearchTest {
         val observer = constructorIo.getSearchResults("2% cheese").test()
         val request = mockServer.takeRequest()
         val path = "/search/2%25%20cheese?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.2&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
+    fun getSearchResultsWithFiltersUsingBuilder() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        mockServer.enqueue(mockResponse)
+        val filters = mapOf(
+            "Brand" to listOf("Signature Farms", "Del Monte"),
+            "Nutrition" to listOf("Organic")
+        )
+        val searchRequest = SearchRequest.Builder("bbq")
+                .setFilters(filters)
+                .build()
+        val observer = constructorIo.getSearchResults(searchRequest).test()
+        val request = mockServer.takeRequest()
+        val path = "/search/bbq?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.1"
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/data/builder/AutocompleteRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/AutocompleteRequestTest.kt
@@ -1,0 +1,98 @@
+package io.constructor.data.builder
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AutocompleteRequestTest {
+
+    private val query = "rose"
+
+    @Test
+    fun autocompleteRequestWithTermUsingBuilder() {
+        val request = AutocompleteRequest.Builder()
+            .setTerm(query)
+            .build()
+        assertEquals(request.term, query)
+    }
+
+    @Test
+    fun autocompleteRequestWithFiltersUsingBuilder() {
+        val filters = mapOf(
+            "Brand" to listOf("XYZ", "123"),
+            "group_id" to listOf("123"),
+        )
+        val request = AutocompleteRequest.Builder()
+            .setTerm(query)
+            .setFilters(filters)
+            .build()
+        assertEquals(request.filters, filters)
+    }
+
+    @Test
+    fun autocompleteRequestWithNumResultsPerSectionUsingBuilder() {
+        val numResultsPerSection = mapOf(
+            "Products" to 5,
+            "Search Suggestions" to 8,
+        )
+        val request = AutocompleteRequest.Builder()
+            .setTerm(query)
+            .setNumResultsPerSection(numResultsPerSection)
+            .build()
+        assertEquals(request.numResultsPerSection, numResultsPerSection)
+    }
+
+    @Test
+    fun autocompleteRequestWithHiddenFieldsUsingBuilder() {
+        val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
+        val request = AutocompleteRequest.Builder()
+            .setTerm(query)
+            .setHiddenFields(hiddenFields)
+            .build()
+        assertEquals(request.hiddenFields, hiddenFields)
+    }
+
+    @Test
+    fun autocompleteRequestWithTermUsingDSL() {
+        val request = AutocompleteRequest.build {
+            term = query
+        }
+        assertEquals(request.term, query)
+    }
+
+    @Test
+    fun autocompleteRequestWithFiltersUsingDSL() {
+        val filtersToApply = mapOf(
+                "Brand" to listOf("XYZ", "123"),
+                "group_id" to listOf("123"),
+        )
+        val request = AutocompleteRequest.build {
+            term = query
+            filters = filtersToApply
+        }
+        assertEquals(request.term, query)
+        assertEquals(request.filters, filtersToApply)
+    }
+
+    @Test
+    fun autocompleteRequestWithNumResultsPerSectionUsingDSL() {
+        val numResultsPerSectionToApply = mapOf(
+                "Products" to 5,
+                "Search Suggestions" to 8,
+        )
+        val request = AutocompleteRequest.build {
+            term = query
+            numResultsPerSection = numResultsPerSectionToApply
+        }
+        assertEquals(request.numResultsPerSection, numResultsPerSectionToApply)
+    }
+
+    @Test
+    fun autocompleteRequestWithHiddenFieldsUsingDSL() {
+        val hiddenFieldsToApply = listOf("hidden_field_1", "hidden_field_2")
+        val request = AutocompleteRequest.build {
+            term = query
+            hiddenFields = hiddenFieldsToApply
+        }
+        assertEquals(request.hiddenFields, hiddenFieldsToApply)
+    }
+}

--- a/library/src/test/java/io/constructor/data/builder/AutocompleteRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/AutocompleteRequestTest.kt
@@ -4,8 +4,17 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class AutocompleteRequestTest {
-
     private val query = "rose"
+    private val filters = mapOf(
+        "Brand" to listOf("XYZ", "123"),
+        "group_id" to listOf("123"),
+    )
+    private val numResultsPerSection = mapOf(
+        "Products" to 5,
+        "Search Suggestions" to 8,
+    )
+    private val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
+
 
     @Test
     fun autocompleteRequestWithTermUsingBuilder() {
@@ -15,10 +24,6 @@ class AutocompleteRequestTest {
 
     @Test
     fun autocompleteRequestWithFiltersUsingBuilder() {
-        val filters = mapOf(
-            "Brand" to listOf("XYZ", "123"),
-            "group_id" to listOf("123"),
-        )
         val request = AutocompleteRequest.Builder(query)
             .setFilters(filters)
             .build()
@@ -27,10 +32,6 @@ class AutocompleteRequestTest {
 
     @Test
     fun autocompleteRequestWithNumResultsPerSectionUsingBuilder() {
-        val numResultsPerSection = mapOf(
-            "Products" to 5,
-            "Search Suggestions" to 8,
-        )
         val request = AutocompleteRequest.Builder(query)
             .setNumResultsPerSection(numResultsPerSection)
             .build()
@@ -39,7 +40,6 @@ class AutocompleteRequestTest {
 
     @Test
     fun autocompleteRequestWithHiddenFieldsUsingBuilder() {
-        val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
         val request = AutocompleteRequest.Builder(query)
             .setHiddenFields(hiddenFields)
             .build()
@@ -47,42 +47,14 @@ class AutocompleteRequestTest {
     }
 
     @Test
-    fun autocompleteRequestWithTermUsingDSL() {
-        val request = AutocompleteRequest.build(query)
-        assertEquals(request.term, query)
-    }
-
-    @Test
-    fun autocompleteRequestWithFiltersUsingDSL() {
-        val filtersToApply = mapOf(
-                "Brand" to listOf("XYZ", "123"),
-                "group_id" to listOf("123"),
-        )
+    fun autocompleteRequestUsingDSL() {
         val request = AutocompleteRequest.build(query) {
-            filters = filtersToApply
+            filters = this@AutocompleteRequestTest.filters
+            numResultsPerSection = this@AutocompleteRequestTest.numResultsPerSection
+            hiddenFields = this@AutocompleteRequestTest.hiddenFields
         }
         assertEquals(request.term, query)
-        assertEquals(request.filters, filtersToApply)
-    }
-
-    @Test
-    fun autocompleteRequestWithNumResultsPerSectionUsingDSL() {
-        val numResultsPerSectionToApply = mapOf(
-                "Products" to 5,
-                "Search Suggestions" to 8,
-        )
-        val request = AutocompleteRequest.build(query) {
-            numResultsPerSection = numResultsPerSectionToApply
-        }
-        assertEquals(request.numResultsPerSection, numResultsPerSectionToApply)
-    }
-
-    @Test
-    fun autocompleteRequestWithHiddenFieldsUsingDSL() {
-        val hiddenFieldsToApply = listOf("hidden_field_1", "hidden_field_2")
-        val request = AutocompleteRequest.build(query) {
-            hiddenFields = hiddenFieldsToApply
-        }
-        assertEquals(request.hiddenFields, hiddenFieldsToApply)
+        assertEquals(request.filters, filters)
+        assertEquals(request.hiddenFields, hiddenFields)
     }
 }

--- a/library/src/test/java/io/constructor/data/builder/AutocompleteRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/AutocompleteRequestTest.kt
@@ -9,9 +9,7 @@ class AutocompleteRequestTest {
 
     @Test
     fun autocompleteRequestWithTermUsingBuilder() {
-        val request = AutocompleteRequest.Builder()
-            .setTerm(query)
-            .build()
+        val request = AutocompleteRequest.Builder(query).build()
         assertEquals(request.term, query)
     }
 
@@ -21,8 +19,7 @@ class AutocompleteRequestTest {
             "Brand" to listOf("XYZ", "123"),
             "group_id" to listOf("123"),
         )
-        val request = AutocompleteRequest.Builder()
-            .setTerm(query)
+        val request = AutocompleteRequest.Builder(query)
             .setFilters(filters)
             .build()
         assertEquals(request.filters, filters)
@@ -34,8 +31,7 @@ class AutocompleteRequestTest {
             "Products" to 5,
             "Search Suggestions" to 8,
         )
-        val request = AutocompleteRequest.Builder()
-            .setTerm(query)
+        val request = AutocompleteRequest.Builder(query)
             .setNumResultsPerSection(numResultsPerSection)
             .build()
         assertEquals(request.numResultsPerSection, numResultsPerSection)
@@ -44,8 +40,7 @@ class AutocompleteRequestTest {
     @Test
     fun autocompleteRequestWithHiddenFieldsUsingBuilder() {
         val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
-        val request = AutocompleteRequest.Builder()
-            .setTerm(query)
+        val request = AutocompleteRequest.Builder(query)
             .setHiddenFields(hiddenFields)
             .build()
         assertEquals(request.hiddenFields, hiddenFields)
@@ -53,9 +48,7 @@ class AutocompleteRequestTest {
 
     @Test
     fun autocompleteRequestWithTermUsingDSL() {
-        val request = AutocompleteRequest.build {
-            term = query
-        }
+        val request = AutocompleteRequest.build(query)
         assertEquals(request.term, query)
     }
 
@@ -65,8 +58,7 @@ class AutocompleteRequestTest {
                 "Brand" to listOf("XYZ", "123"),
                 "group_id" to listOf("123"),
         )
-        val request = AutocompleteRequest.build {
-            term = query
+        val request = AutocompleteRequest.build(query) {
             filters = filtersToApply
         }
         assertEquals(request.term, query)
@@ -79,8 +71,7 @@ class AutocompleteRequestTest {
                 "Products" to 5,
                 "Search Suggestions" to 8,
         )
-        val request = AutocompleteRequest.build {
-            term = query
+        val request = AutocompleteRequest.build(query) {
             numResultsPerSection = numResultsPerSectionToApply
         }
         assertEquals(request.numResultsPerSection, numResultsPerSectionToApply)
@@ -89,8 +80,7 @@ class AutocompleteRequestTest {
     @Test
     fun autocompleteRequestWithHiddenFieldsUsingDSL() {
         val hiddenFieldsToApply = listOf("hidden_field_1", "hidden_field_2")
-        val request = AutocompleteRequest.build {
-            term = query
+        val request = AutocompleteRequest.build(query) {
             hiddenFields = hiddenFieldsToApply
         }
         assertEquals(request.hiddenFields, hiddenFieldsToApply)

--- a/library/src/test/java/io/constructor/data/builder/BrowseRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/BrowseRequestTest.kt
@@ -1,0 +1,104 @@
+package io.constructor.data.builder
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class BrowseRequestTest {
+    private val filterName = "group_id"
+    private val filterValue = "123"
+    private val filtersToApply = mapOf(
+            "Brand" to listOf("XYZ", "123"),
+            "group_id" to listOf("123"),
+    )
+    private val page = 2
+    private val perPage = 30
+    private val sortBy = "relevance"
+    private val sortOrder = "ascending"
+    private val section = "Search Suggestions"
+    private val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
+    private val hiddenFacets = listOf("hidden_facet_1", "hidden_facet_2")
+
+    @Test
+    fun browseRequestUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue).build()
+        assertEquals(request.filterName, filterName)
+        assertEquals(request.filterValue, filterValue)
+    }
+
+    @Test
+    fun browseRequestWithFiltersUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setFilters(filtersToApply)
+                .build()
+        assertEquals(request.filters, filtersToApply)
+    }
+
+    @Test
+    fun browseRequestWithPageParamsUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setPage(page)
+                .setPerPage(perPage)
+                .build()
+        assertEquals(request.page, page)
+        assertEquals(request.perPage, perPage)
+    }
+
+    @Test
+    fun browseRequestWithSortOptionUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setSortBy(sortBy)
+                .setSortOrder(sortOrder)
+                .build()
+        assertEquals(request.sortBy, sortBy)
+        assertEquals(request.sortOrder, sortOrder)
+    }
+
+    @Test
+    fun browseRequestWithSectionUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setSection(section)
+                .build()
+        assertEquals(request.section, section)
+    }
+
+    @Test
+    fun browseRequestWithHiddenFieldsUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setHiddenFields(hiddenFields)
+                .build()
+        assertEquals(request.hiddenFields, hiddenFields)
+    }
+
+    @Test
+    fun browseRequestWithHiddenFacetsUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setHiddenFacets(hiddenFacets)
+                .build()
+        assertEquals(request.hiddenFacets, hiddenFacets)
+    }
+
+    @Test
+    fun browseRequestWithParamsUsingDSL() {
+        val request = BrowseRequest.build(filterName, filterValue) {
+            filters = this@BrowseRequestTest.filtersToApply
+            page = this@BrowseRequestTest.page
+            perPage = this@BrowseRequestTest.perPage
+            sortBy = this@BrowseRequestTest.sortBy
+            sortOrder = this@BrowseRequestTest.sortOrder
+            section = this@BrowseRequestTest.section
+            hiddenFields = this@BrowseRequestTest.hiddenFields
+            hiddenFacets = this@BrowseRequestTest.hiddenFacets
+        }
+
+        assertEquals(request.filterName, filterName)
+        assertEquals(request.filterValue, filterValue)
+        assertEquals(request.filters, filtersToApply)
+        assertEquals(request.page, page)
+        assertEquals(request.perPage, perPage)
+        assertEquals(request.sortBy, sortBy)
+        assertEquals(request.sortOrder, sortOrder)
+        assertEquals(request.section, section)
+        assertEquals(request.hiddenFields, hiddenFields)
+        assertEquals(request.hiddenFacets, hiddenFacets)
+    }
+}

--- a/library/src/test/java/io/constructor/data/builder/RecommendationsRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/RecommendationsRequestTest.kt
@@ -1,0 +1,80 @@
+package io.constructor.data.builder
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class RecommendationsRequestTest {
+    private val podId = "product_detail_page"
+    private val filtersToApply = mapOf(
+        "Brand" to listOf("XYZ", "123"),
+        "group_id" to listOf("123"),
+    )
+    private val itemIds = listOf("123")
+    private val term = "some zero results query"
+    private val numResults = 5
+    private val section = "Recommendations Suggestions"
+
+    @Test
+    fun recommendationsRequestUsingBuilder() {
+        val request = RecommendationsRequest.Builder(podId).build()
+        assertEquals(request.podId, podId)
+    }
+
+    @Test
+    fun recommendationsRequestWithFiltersUsingBuilder() {
+        val request = RecommendationsRequest.Builder(podId)
+            .setFilters(filtersToApply)
+            .build()
+        assertEquals(request.filters, filtersToApply)
+    }
+
+    @Test
+    fun recommendationsRequestWithNumResultsUsingBuilder() {
+        val request = RecommendationsRequest.Builder(podId)
+            .setNumResults(numResults)
+            .build()
+        assertEquals(request.numResults, numResults)
+    }
+
+    @Test
+    fun recommendationsRequestWithItemIdsUsingBuilder() {
+        val request = RecommendationsRequest.Builder(podId)
+            .setItemIds(itemIds)
+            .build()
+        assertEquals(request.itemIds, itemIds)
+    }
+
+    @Test
+    fun recommendationsRequestWithTermUsingBuilder() {
+        val request = RecommendationsRequest.Builder(podId)
+            .setTerm(term)
+            .build()
+        assertEquals(request.term, term)
+    }
+
+    @Test
+    fun recommendationsRequestWithSectionUsingBuilder() {
+        val request = RecommendationsRequest.Builder(podId)
+            .setSection(section)
+            .build()
+        assertEquals(request.section, section)
+    }
+
+    @Test
+    fun recommendationsRequestWithParamsUsingDSL() {
+        val request = RecommendationsRequest.build(podId) {
+            filters = this@RecommendationsRequestTest.filtersToApply
+            itemIds = this@RecommendationsRequestTest.itemIds
+            term = this@RecommendationsRequestTest.term
+            numResults = this@RecommendationsRequestTest.numResults
+            section = this@RecommendationsRequestTest.section
+        }
+
+        assertEquals(request.podId, podId)
+        assertEquals(request.filters, filtersToApply)
+        assertEquals(request.itemIds, itemIds)
+        assertEquals(request.term, term)
+        assertEquals(request.numResults, numResults)
+        assertEquals(request.section, section)
+    }
+}

--- a/library/src/test/java/io/constructor/data/builder/SearchRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/SearchRequestTest.kt
@@ -1,0 +1,101 @@
+package io.constructor.data.builder
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SearchRequestTest {
+    private val query = "rose"
+    private val filtersToApply = mapOf(
+        "Brand" to listOf("XYZ", "123"),
+        "group_id" to listOf("123"),
+    )
+    private val page = 2
+    private val perPage = 30
+    private val sortBy = "relevance"
+    private val sortOrder = "ascending"
+    private val section = "Search Suggestions"
+    private val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
+    private val hiddenFacets = listOf("hidden_facet_1", "hidden_facet_2")
+
+    @Test
+    fun searchRequestWithTermUsingBuilder() {
+        val request = SearchRequest.Builder(query).build()
+        assertEquals(request.term, query)
+    }
+
+    @Test
+    fun searchRequestWithFiltersUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+            .setFilters(filtersToApply)
+            .build()
+        assertEquals(request.filters, filtersToApply)
+    }
+
+    @Test
+    fun searchRequestWithPageParamsUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+            .setPage(page)
+            .setPerPage(perPage)
+            .build()
+        assertEquals(request.page, page)
+        assertEquals(request.perPage, perPage)
+    }
+
+    @Test
+    fun searchRequestWithSortOptionUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+            .setSortBy(sortBy)
+            .setSortOrder(sortOrder)
+            .build()
+        assertEquals(request.sortBy, sortBy)
+        assertEquals(request.sortOrder, sortOrder)
+    }
+
+    @Test
+    fun searchRequestWithSectionUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+                .setSection(section)
+                .build()
+        assertEquals(request.section, section)
+    }
+
+    @Test
+    fun searchRequestWithHiddenFieldsUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+                .setHiddenFields(hiddenFields)
+                .build()
+        assertEquals(request.hiddenFields, hiddenFields)
+    }
+
+    @Test
+    fun searchRequestWithHiddenFacetsUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+                .setHiddenFacets(hiddenFacets)
+                .build()
+        assertEquals(request.hiddenFacets, hiddenFacets)
+    }
+
+    @Test
+    fun searchRequestWithParamsUsingDSL() {
+        val request = SearchRequest.build(query) {
+            filters = this@SearchRequestTest.filtersToApply
+            page = this@SearchRequestTest.page
+            perPage = this@SearchRequestTest.perPage
+            sortBy = this@SearchRequestTest.sortBy
+            sortOrder = this@SearchRequestTest.sortOrder
+            section = this@SearchRequestTest.section
+            hiddenFields = this@SearchRequestTest.hiddenFields
+            hiddenFacets = this@SearchRequestTest.hiddenFacets
+        }
+
+        assertEquals(request.term, query)
+        assertEquals(request.filters, filtersToApply)
+        assertEquals(request.page, page)
+        assertEquals(request.perPage, perPage)
+        assertEquals(request.sortBy, sortBy)
+        assertEquals(request.sortOrder, sortOrder)
+        assertEquals(request.section, section)
+        assertEquals(request.hiddenFields, hiddenFields)
+        assertEquals(request.hiddenFacets, hiddenFacets)
+    }
+}


### PR DESCRIPTION
### Updates:
* Add support for request builders + DSL
* Add tests (all tests pass)

Example using request builder:
```
val request = AutocompleteRequest.Builder("potato")
    .setNumResultsPerSection(mapOf(
        "Products" to 6,
        "Search Suggestions" to 8
    ))
    .setFilters(mapOf(
        "group_id" to listOf("G123"),
        "availability" to listOf("US", "CA")
    ))
    .build()

constructorIo.getAutocompleteResults(request)
```

Example using builder DSL:
```
val request = SearchRequest.build("potato") {
    filters = mapOf(
        "group_id" to listOf("G123"),
        "Brand" to listOf("Kings Hawaiin")
    )
    hiddenFields = listOf("hidden_field_1", "hidden_field_2")
}

constructorIo.getSearchResults(request)
```
