### PR TITLE
[CSL 1381] Add support for groups sort format option

### DIFF
--- a/library/src/main/java/io/constructor/core/Constants.kt
+++ b/library/src/main/java/io/constructor/core/Constants.kt
@@ -40,6 +40,8 @@ class Constants {
         const val FMT_OPTIONS = "fmt_options[%s]"
         const val HIDDEN_FIELD = "hidden_fields"
         const val HIDDEN_FACET = "hidden_facets"
+        const val GROUPS_SORT_BY = "groups_sort_by"
+        const val GROUPS_SORT_ORDER = "groups_sort_order"
         const val RESULT_ID = "result_id"
         const val FILTER_NAME = "filter_name"
         const val FILTER_VALUE = "filter_value"

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -12,17 +12,17 @@ import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.data.model.autocomplete.AutocompleteResponse
-import io.constructor.data.model.common.ResultGroup
-import io.constructor.data.model.search.SearchResponse
 import io.constructor.data.model.browse.BrowseResponse
-import io.constructor.data.model.recommendations.RecommendationsResponse
 import io.constructor.data.model.browse.BrowseResultClickRequestBody
 import io.constructor.data.model.browse.BrowseResultLoadRequestBody
+import io.constructor.data.model.common.ResultGroup
+import io.constructor.data.model.conversion.ConversionRequestBody
 import io.constructor.data.model.purchase.PurchaseItem
 import io.constructor.data.model.purchase.PurchaseRequestBody
-import io.constructor.data.model.conversion.ConversionRequestBody
 import io.constructor.data.model.recommendations.RecommendationResultClickRequestBody
 import io.constructor.data.model.recommendations.RecommendationResultViewRequestBody
+import io.constructor.data.model.recommendations.RecommendationsResponse
+import io.constructor.data.model.search.SearchResponse
 import io.constructor.injection.component.AppComponent
 import io.constructor.injection.component.DaggerAppComponent
 import io.constructor.injection.module.AppModule
@@ -239,8 +239,10 @@ object ConstructorIo {
      * @param sectionName the section the results will come from defaults to "Products"
      * @param hiddenFields show fields that are hidden by default
      * @param hiddenFacets show facets that are hidden by default
+     * @param groupsSortBy the sort method for groups
+     * @param groupsSortOrder the sort order for groups
      */
-    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null, hiddenFacets: List<String>? = null): Observable<ConstructorData<SearchResponse>> {
+    fun getSearchResults(term: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null, hiddenFacets: List<String>? = null, groupsSortBy: String? = null, groupsSortOrder: String? = null): Observable<ConstructorData<SearchResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
 
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
@@ -260,7 +262,8 @@ object ConstructorIo {
         hiddenFacets?.forEach { hiddenFacet ->
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
         }
-
+        groupsSortBy?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_BY).urlEncode() to groupsSortBy.urlEncode()) }
+        groupsSortOrder?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_ORDER).urlEncode() to groupsSortOrder.urlEncode()) }
         return dataManager.getSearchResults(term.urlEncode(), encodedParams = encodedParams.toTypedArray())
     }
 
@@ -346,8 +349,10 @@ object ConstructorIo {
      * @param sectionName the section the results will come from defaults to "Products"
      * @param hiddenFields show fields that are hidden by default
      * @param hiddenFacets show facets that are hidden by default
+     * @param groupsSortBy the sort method for groups
+     * @param groupsSortOrder the sort order for groups
      */
-    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null, hiddenFacets: List<String>? = null): Observable<ConstructorData<BrowseResponse>> {
+    fun getBrowseResults(filterName: String, filterValue: String, facets: List<Pair<String, List<String>>>? = null, page: Int? = null, perPage: Int? = null, groupId: Int? = null, sortBy: String? = null, sortOrder: String? = null, sectionName: String? = null, hiddenFields: List<String>? = null, hiddenFacets: List<String>? = null, groupsSortBy: String? = null, groupsSortOrder: String? = null): Observable<ConstructorData<BrowseResponse>> {
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         groupId?.let { encodedParams.add(Constants.QueryConstants.FILTER_GROUP_ID.urlEncode() to it.toString()) }
         page?.let { encodedParams.add(Constants.QueryConstants.PAGE.urlEncode() to page.toString().urlEncode()) }
@@ -366,6 +371,8 @@ object ConstructorIo {
         hiddenFacets?.forEach { hiddenFacet ->
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
         }
+        groupsSortBy?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_BY).urlEncode() to groupsSortBy.urlEncode()) }
+        groupsSortOrder?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_ORDER).urlEncode() to groupsSortOrder.urlEncode()) }
         return dataManager.getBrowseResults(filterName, filterValue, encodedParams = encodedParams.toTypedArray())
     }
 

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -319,6 +319,8 @@ object ConstructorIo {
         request.hiddenFacets?.forEach { hiddenFacet ->
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
         }
+        request.groupsSortBy?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_BY).urlEncode() to it.urlEncode()) }
+        request.groupsSortOrder?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_ORDER).urlEncode() to it.urlEncode()) }
 
         return dataManager.getSearchResults(request.term.urlEncode(), encodedParams = encodedParams.toTypedArray())
     }
@@ -428,6 +430,8 @@ object ConstructorIo {
         request.hiddenFacets?.forEach { hiddenFacet ->
             encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.HIDDEN_FACET).urlEncode() to hiddenFacet.urlEncode())
         }
+        request.groupsSortBy?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_BY).urlEncode() to it.urlEncode()) }
+        request.groupsSortOrder?.let { encodedParams.add(Constants.QueryConstants.FMT_OPTIONS.format(Constants.QueryConstants.GROUPS_SORT_ORDER).urlEncode() to it.urlEncode()) }
 
         return dataManager.getBrowseResults(request.filterName, request.filterValue, encodedParams = encodedParams.toTypedArray())
     }

--- a/library/src/main/java/io/constructor/data/builder/BrowseRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/BrowseRequest.kt
@@ -14,6 +14,8 @@ class BrowseRequest (
     val section: String? = null,
     val hiddenFields: List<String>? = null,
     val hiddenFacets: List<String>? = null,
+    val groupsSortBy: String? = null,
+    val groupsSortOrder: String? = null,
 ) {
     private constructor(builder: Builder) : this(
         builder.filterName,
@@ -26,6 +28,8 @@ class BrowseRequest (
         builder.section,
         builder.hiddenFields,
         builder.hiddenFacets,
+        builder.groupsSortBy,
+        builder.groupsSortOrder,
     )
 
     companion object {
@@ -44,6 +48,8 @@ class BrowseRequest (
         var section: String? = null
         var hiddenFields: List<String>? = null
         var hiddenFacets: List<String>? = null
+        var groupsSortBy: String? = null
+        var groupsSortOrder: String? = null
 
         fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
         fun setPage(page: Int): Builder = apply { this.page = page }
@@ -53,6 +59,8 @@ class BrowseRequest (
         fun setSection(section: String): Builder = apply { this.section = section }
         fun setHiddenFields(hiddenFields: List<String>): Builder = apply { this.hiddenFields = hiddenFields }
         fun setHiddenFacets(hiddenFacets: List<String>): Builder = apply { this.hiddenFacets = hiddenFacets }
+        fun setGroupsSortBy(groupsSortBy: String): Builder = apply { this.groupsSortBy = groupsSortBy }
+        fun setGroupsSortOrder(groupsSortOrder: String): Builder = apply { this.groupsSortOrder = groupsSortOrder }
         fun build(): BrowseRequest = BrowseRequest(this)
     }
 }

--- a/library/src/main/java/io/constructor/data/builder/SearchRequest.kt
+++ b/library/src/main/java/io/constructor/data/builder/SearchRequest.kt
@@ -13,6 +13,8 @@ class SearchRequest (
     val section: String? = null,
     val hiddenFields: List<String>? = null,
     val hiddenFacets: List<String>? = null,
+    val groupsSortBy: String? = null,
+    val groupsSortOrder: String? = null,
 ) {
     private constructor(builder: Builder) : this(
         builder.term,
@@ -24,6 +26,8 @@ class SearchRequest (
         builder.section,
         builder.hiddenFields,
         builder.hiddenFacets,
+        builder.groupsSortBy,
+        builder.groupsSortOrder,
     )
 
     companion object {
@@ -41,6 +45,8 @@ class SearchRequest (
         var section: String? = null
         var hiddenFields: List<String>? = null
         var hiddenFacets: List<String>? = null
+        var groupsSortBy: String? = null
+        var groupsSortOrder: String? = null
 
         fun setFilters(facets: Map<String, List<String>>): Builder = apply { this.filters = facets }
         fun setPage(page: Int): Builder = apply { this.page = page }
@@ -50,6 +56,8 @@ class SearchRequest (
         fun setSection(section: String): Builder = apply { this.section = section }
         fun setHiddenFields(hiddenFields: List<String>): Builder = apply { this.hiddenFields = hiddenFields }
         fun setHiddenFacets(hiddenFacets: List<String>): Builder = apply { this.hiddenFacets = hiddenFacets }
+        fun setGroupsSortBy(groupsSortBy: String): Builder = apply { this.groupsSortBy = groupsSortBy }
+        fun setGroupsSortOrder(groupsSortOrder: String): Builder = apply { this.groupsSortOrder = groupsSortOrder }
         fun build(): SearchRequest = SearchRequest(this)
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -239,6 +239,36 @@ class ConstructorIoIntegrationTest {
     }
 
     @Test
+    fun getSearchResultsWithGroupsSortValueAscendingAgainstRealResponse() {
+        val observer = constructorIo.getSearchResults(
+            term = "pork",
+            groupsSortBy = "value",
+            groupsSortOrder = "ascending"
+        ).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.groups!!.isNotEmpty()
+            it.get()?.response?.groups?.get(0)?.displayName == "Dairy"
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
+    fun getSearchResultsWithGroupsSortValueDescendingAgainstRealResponse() {
+        val observer = constructorIo.getSearchResults(
+            term = "pork",
+            groupsSortBy = "value",
+            groupsSortOrder = "descending"
+        ).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.groups!!.isNotEmpty()
+            it.get()?.response?.groups?.get(0)?.displayName == "Meat & Poultry"
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
     fun getBrowseResultsWithHiddenFieldsAgainstRealResponse() {
         val hiddenFields = listOf("hiddenField1", "hiddenField2")
         val observer = constructorIo.getBrowseResults("group_id", "431", null, null, null, null, null, null, null, hiddenFields).test()
@@ -325,6 +355,40 @@ class ConstructorIoIntegrationTest {
             it.get()?.response?.pod !== null
             it.get()?.response?.results !== null
             it.get()?.response?.resultCount!! >= 0
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
+    fun getBrowseResultsWithGroupsSortValueAscendingAgainstRealResponse() {
+        val observer = constructorIo.getBrowseResults(
+            filterName = "group_id",
+            filterValue = "431",
+            groupsSortBy = "value",
+            groupsSortOrder = "ascending",
+        ).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.groups!!.isNotEmpty()
+            it.get()?.response?.groups?.get(0)?.displayName == "Grocery"
+            it.get()?.response?.groups?.get(0)?.children?.get(0)?.displayName == "Baby"
+        }
+        Thread.sleep(timeBetweenTests)
+    }
+
+    @Test
+    fun getBrowseResultsWithGroupsSortValueDescendingAgainstRealResponse() {
+        val observer = constructorIo.getBrowseResults(
+            filterName = "group_id",
+            filterValue = "431",
+            groupsSortBy = "value",
+            groupsSortOrder = "descending",
+        ).test()
+        observer.assertComplete().assertValue {
+            it.get()?.resultId !== null
+            it.get()?.response?.groups!!.isNotEmpty()
+            it.get()?.response?.groups?.get(0)?.displayName == "Grocery"
+            it.get()?.response?.groups?.get(0)?.children?.get(0)?.displayName == "Pet"
         }
         Thread.sleep(timeBetweenTests)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -2,7 +2,6 @@ package io.constructor.core
 
 import android.content.Context
 import io.constructor.data.builder.BrowseRequest
-import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.test.createTestDataManager
@@ -173,6 +172,16 @@ class ConstructorIoBrowseTest {
     }
 
     @Test
+    fun getBrowseResultWithGroupsSort() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getBrowseResults(filterName = "group_id", filterValue = "Beverages", groupsSortBy = "value", groupsSortOrder = "ascending").test()
+        val request = mockServer.takeRequest()
+        val path = "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun getBrowseResultsWithFiltersUsingBuilder() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
@@ -181,8 +190,8 @@ class ConstructorIoBrowseTest {
             "Nutrition" to listOf("Organic")
         )
         val browseRequest = BrowseRequest.Builder("group_id", "Beverages")
-                .setFilters(filters)
-                .build()
+            .setFilters(filters)
+            .build()
         val observer = constructorIo.getBrowseResults(browseRequest).test()
         val request = mockServer.takeRequest()
         val path = "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0&_dt="
@@ -190,12 +199,16 @@ class ConstructorIoBrowseTest {
     }
 
     @Test
-    fun getBrowseResultWithGroupsSort() {
+    fun getBrowseResultsWithGroupsSortUsingBuilder() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults(filterName = "group_id", filterValue = "Beverages", groupsSortBy = "value", groupsSortOrder = "ascending").test()
+        val browseRequest = BrowseRequest.Builder("group_id", "Beverages")
+            .setGroupsSortBy("value")
+            .setGroupsSortOrder("ascending")
+            .build()
+        val observer = constructorIo.getBrowseResults(browseRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.2&_dt="
+        val path = "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -188,4 +188,14 @@ class ConstructorIoBrowseTest {
         val path = "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0&_dt="
         assert(request.path!!.startsWith(path))
     }
+
+    @Test
+    fun getBrowseResultWithGroupsSort() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getBrowseResults(filterName = "group_id", filterValue = "Beverages", groupsSortBy = "value", groupsSortOrder = "ascending").test()
+        val request = mockServer.takeRequest()
+        val path = "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.2&_dt="
+        assert(request.path!!.startsWith(path))
+    }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -202,4 +202,14 @@ class ConstructorIoSearchTest {
         val path = "/search/bbq?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0"
         assert(request.path!!.startsWith(path))
     }
+
+    @Test
+    fun getSearchResultsWithGroupsSort() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getSearchResults(term = "bbq", groupsSortBy = "value", groupsSortOrder = "descending").test()
+        val request = mockServer.takeRequest()
+        val path = "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=descending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.2&_dt="
+        assert(request.path!!.startsWith(path))
+    }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -187,6 +187,16 @@ class ConstructorIoSearchTest {
     }
 
     @Test
+    fun getSearchResultsWithGroupsSort() {
+        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getSearchResults(term = "bbq", groupsSortBy = "value", groupsSortOrder = "descending").test()
+        val request = mockServer.takeRequest()
+        val path = "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=descending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun getSearchResultsWithFiltersUsingBuilder() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
@@ -204,12 +214,16 @@ class ConstructorIoSearchTest {
     }
 
     @Test
-    fun getSearchResultsWithGroupsSort() {
+    fun getSearchResultsWithGroupsSortUsingBuilder() {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults(term = "bbq", groupsSortBy = "value", groupsSortOrder = "descending").test()
+        val searchRequest = SearchRequest.Builder("bbq")
+                .setGroupsSortBy("value")
+                .setGroupsSortOrder("ascending")
+                .build()
+        val observer = constructorIo.getSearchResults(searchRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=descending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.14.2&_dt="
+        val path = "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.15.0&_dt="
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/data/builder/BrowseRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/BrowseRequestTest.kt
@@ -17,6 +17,8 @@ class BrowseRequestTest {
     private val section = "Search Suggestions"
     private val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
     private val hiddenFacets = listOf("hidden_facet_1", "hidden_facet_2")
+    private val groupsSortBy = "value"
+    private val groupsSortOrder = "ascending"
 
     @Test
     fun browseRequestUsingBuilder() {
@@ -78,6 +80,16 @@ class BrowseRequestTest {
     }
 
     @Test
+    fun browseRequestWithGroupsSortOptionUsingBuilder() {
+        val request = BrowseRequest.Builder(filterName, filterValue)
+                .setGroupsSortBy(groupsSortBy)
+                .setGroupsSortOrder(groupsSortOrder)
+                .build()
+        assertEquals(request.groupsSortBy, groupsSortBy)
+        assertEquals(request.groupsSortOrder, groupsSortOrder)
+    }
+
+    @Test
     fun browseRequestWithParamsUsingDSL() {
         val request = BrowseRequest.build(filterName, filterValue) {
             filters = this@BrowseRequestTest.filtersToApply
@@ -88,6 +100,8 @@ class BrowseRequestTest {
             section = this@BrowseRequestTest.section
             hiddenFields = this@BrowseRequestTest.hiddenFields
             hiddenFacets = this@BrowseRequestTest.hiddenFacets
+            groupsSortBy = this@BrowseRequestTest.groupsSortBy
+            groupsSortOrder = this@BrowseRequestTest.groupsSortOrder
         }
 
         assertEquals(request.filterName, filterName)
@@ -100,5 +114,7 @@ class BrowseRequestTest {
         assertEquals(request.section, section)
         assertEquals(request.hiddenFields, hiddenFields)
         assertEquals(request.hiddenFacets, hiddenFacets)
+        assertEquals(request.groupsSortBy, groupsSortBy)
+        assertEquals(request.groupsSortOrder, groupsSortOrder)
     }
 }

--- a/library/src/test/java/io/constructor/data/builder/SearchRequestTest.kt
+++ b/library/src/test/java/io/constructor/data/builder/SearchRequestTest.kt
@@ -16,6 +16,8 @@ class SearchRequestTest {
     private val section = "Search Suggestions"
     private val hiddenFields = listOf("hidden_field_1", "hidden_field_2")
     private val hiddenFacets = listOf("hidden_facet_1", "hidden_facet_2")
+    private val groupsSortBy = "value"
+    private val groupsSortOrder = "ascending"
 
     @Test
     fun searchRequestWithTermUsingBuilder() {
@@ -76,6 +78,16 @@ class SearchRequestTest {
     }
 
     @Test
+    fun searchRequestWithGroupsSortOptionUsingBuilder() {
+        val request = SearchRequest.Builder(query)
+                .setGroupsSortBy(groupsSortBy)
+                .setGroupsSortOrder(groupsSortOrder)
+                .build()
+        assertEquals(request.groupsSortBy, groupsSortBy)
+        assertEquals(request.groupsSortOrder, groupsSortOrder)
+    }
+
+    @Test
     fun searchRequestWithParamsUsingDSL() {
         val request = SearchRequest.build(query) {
             filters = this@SearchRequestTest.filtersToApply
@@ -86,6 +98,8 @@ class SearchRequestTest {
             section = this@SearchRequestTest.section
             hiddenFields = this@SearchRequestTest.hiddenFields
             hiddenFacets = this@SearchRequestTest.hiddenFacets
+            groupsSortBy = this@SearchRequestTest.groupsSortBy
+            groupsSortOrder = this@SearchRequestTest.groupsSortOrder
         }
 
         assertEquals(request.term, query)
@@ -97,5 +111,7 @@ class SearchRequestTest {
         assertEquals(request.section, section)
         assertEquals(request.hiddenFields, hiddenFields)
         assertEquals(request.hiddenFacets, hiddenFacets)
+        assertEquals(request.groupsSortBy, groupsSortBy)
+        assertEquals(request.groupsSortOrder, groupsSortOrder)
     }
 }


### PR DESCRIPTION
### Updates:
* Add support for groups sort format option + tests
    * [6/23/22] Updated w/ builders
    * `fmt_options[groups_sort_by]`
        * Possible values are `relevance`, `num_matches` or `value`.
    * `fmt_options[groups_sort_order]`
        * Possible values are `ascending` or `descending`.