### PR TITLE
Fix qualifiers and standardize resources, use Moshi Kotlin Codegen

### DIFF
--- a/library/dependencies.gradle
+++ b/library/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     versions = [
-            moshi   : "1.8.0",
+            moshi   : "1.13.0",
             okHttp  : "4.9.2",
             retrofit: '2.5.0',
             dagger  : '2.35.1',
@@ -21,8 +21,9 @@ ext {
     ]
 
     moshi = [
-            moshi: "com.squareup.moshi:moshi-kotlin:$versions.moshi"
+            moshi: "com.squareup.moshi:moshi:$versions.moshi",
     ]
+    moshiCodeGen = "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi"
 
     okHttp = [
             logger: "com.squareup.okhttp3:logging-interceptor:$versions.okHttp",
@@ -33,6 +34,7 @@ ext {
             supportAnnotation: "androidx.annotation:annotation:1.2.0",
             kotlinTest       : "org.jetbrains.kotlin:kotlin-test:$kotlin_version",
             kotlinJunit      : "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version",
+            assertJ          : "org.assertj:assertj-core:3.23.1"
 
     ] + junit
 
@@ -42,7 +44,7 @@ ext {
     supportLibs = supportDeps.values()
     networkLibs = retrofit.values() + okHttp.values() + moshi.values()
     otherLibs = [dagger]
-    annotationProcessorLibs = [daggerCompiler]
+    annotationProcessorLibs = [daggerCompiler, moshiCodeGen]
 
     unitTestLibs = unitTest.values()
     androidTestsLibs = supportLibs

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -29,7 +29,6 @@ import io.constructor.data.model.search.SearchResponse
 import io.constructor.injection.component.AppComponent
 import io.constructor.injection.component.DaggerAppComponent
 import io.constructor.injection.module.AppModule
-import io.constructor.injection.module.NetworkModule
 import io.constructor.util.broadcastIntent
 import io.constructor.util.e
 import io.constructor.util.urlEncode
@@ -67,7 +66,6 @@ object ConstructorIo {
     internal val component: AppComponent by lazy {
         DaggerAppComponent.builder()
                 .appModule(AppModule(context))
-                .networkModule(NetworkModule(context))
                 .build()
     }
 

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -3,6 +3,7 @@ package io.constructor.core
 import android.annotation.SuppressLint
 import android.content.Context
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.constructor.BuildConfig
 import io.constructor.data.ConstructorData
 import io.constructor.data.DataManager
@@ -51,7 +52,7 @@ object ConstructorIo {
     private lateinit var configMemoryHolder: ConfigMemoryHolder
     private lateinit var context: Context
     private var disposable = CompositeDisposable()
-    private val moshi = Moshi.Builder().build()
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
     private val jsonAdapter = moshi.adapter(VariationsMap::class.java)
 
     /**

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -3,7 +3,6 @@ package io.constructor.core
 import android.annotation.SuppressLint
 import android.content.Context
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.constructor.BuildConfig
 import io.constructor.data.ConstructorData
 import io.constructor.data.DataManager
@@ -51,7 +50,7 @@ object ConstructorIo {
     private lateinit var configMemoryHolder: ConfigMemoryHolder
     private lateinit var context: Context
     private var disposable = CompositeDisposable()
-    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val moshi = Moshi.Builder().build()
     private val jsonAdapter = moshi.adapter(VariationsMap::class.java)
 
     /**

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -13,6 +13,7 @@ import io.constructor.data.model.recommendations.RecommendationResultClickReques
 import io.constructor.data.model.recommendations.RecommendationResultViewRequestBody
 import io.constructor.data.remote.ApiPaths
 import io.constructor.data.remote.ConstructorApi
+import io.constructor.injection.ConstructorSdk
 import io.reactivex.Completable
 import io.reactivex.Observable
 import javax.inject.Inject
@@ -23,7 +24,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class DataManager @Inject
-constructor(private val constructorApi: ConstructorApi, private val moshi: Moshi) {
+constructor(private val constructorApi: ConstructorApi, @ConstructorSdk private val moshi: Moshi) {
 
     fun getAutocompleteResults(term: String, encodedParams: Array<Pair<String, String>> = arrayOf()): Observable<ConstructorData<AutocompleteResponse>> {
         var dynamicUrl = "/${ApiPaths.URL_AUTOCOMPLETE.format(term)}"

--- a/library/src/main/java/io/constructor/data/interceptor/RequestInterceptor.kt
+++ b/library/src/main/java/io/constructor/data/interceptor/RequestInterceptor.kt
@@ -1,6 +1,5 @@
 package io.constructor.data.interceptor
 
-import android.content.Context
 import io.constructor.BuildConfig
 import io.constructor.core.Constants
 import io.constructor.data.local.PreferencesHelper
@@ -12,7 +11,10 @@ import okhttp3.Response
  * @suppress
  * Adds common request query parameters to all API requests
  */
-class RequestInterceptor(val context: Context, private val preferencesHelper: PreferencesHelper, private val configMemoryHolder: ConfigMemoryHolder) : Interceptor {
+class RequestInterceptor(
+    private val preferencesHelper: PreferencesHelper,
+    private val configMemoryHolder: ConfigMemoryHolder
+) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val builder = request.url.newBuilder()

--- a/library/src/main/java/io/constructor/data/local/PreferencesHelper.kt
+++ b/library/src/main/java/io/constructor/data/local/PreferencesHelper.kt
@@ -1,9 +1,8 @@
 package io.constructor.data.local
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.SharedPreferences
-import io.constructor.injection.ApplicationContext
+import io.constructor.injection.ConstructorSdk
 import javax.inject.Inject
 
 /**
@@ -11,10 +10,7 @@ import javax.inject.Inject
  */
 @SuppressLint("CommitPrefEdits")
 class PreferencesHelper @Inject
-constructor(@ApplicationContext context: Context, prefFileName: String = PREF_FILE_NAME) {
-
-    private val preferences: SharedPreferences = context.getSharedPreferences(prefFileName, Context.MODE_PRIVATE)
-
+constructor(@ConstructorSdk val preferences: SharedPreferences) {
     var id: String
         get() = preferences.getString(PREF_ID, "")!!
         set(value) = preferences.edit().putString(PREF_ID, value).apply()
@@ -78,7 +74,6 @@ constructor(@ApplicationContext context: Context, prefFileName: String = PREF_FI
         const val PREF_DEFAULT_ITEM_SECTION = "default_item_section"
         const val PREF_GROUPS_SHOWN_FOR_FIRST_TERM = "groups_shown_for_first_term"
         const val PREF_ID = "id"
-        const val PREF_FILE_NAME = "constructor_pref_file"
         const val SESSION_ID = "session_id"
         const val SESSION_LAST_ACCESS = "session_last_access"
         const val SESSION_TIME_THRESHOLD = 1000 * 60 * 30

--- a/library/src/main/java/io/constructor/data/model/autocomplete/AutocompleteResponse.kt
+++ b/library/src/main/java/io/constructor/data/model/autocomplete/AutocompleteResponse.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.autocomplete
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * Models an autocomplete response
  */
+@JsonClass(generateAdapter = true)
 data class AutocompleteResponse (
         @Json(name = "sections") val sections: Map<String, List<Result>>?,
         @Json(name = "result_id") val resultId: String?,

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResponse.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResponse.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.browse
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models a browse response
  */
+@JsonClass(generateAdapter = true)
 data class BrowseResponse(
         @Json(name = "response") val response: BrowseResponseInner?,
         @Json(name = "result_id") val resultId: String?,

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResponseInner.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResponseInner.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.browse
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * Models browse response details
  */
+@JsonClass(generateAdapter = true)
 data class BrowseResponseInner(
         @Json(name = "collection") val collection: Collection?,
         @Json(name = "facets") val facets: List<FilterFacet>?,

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.browse
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * @suppress
  */
+@JsonClass(generateAdapter = true)
 data class BrowseResultClickRequestBody(
         @Json(name = "filter_name") val filterName: String,
         @Json(name = "filter_value") val filterValue: String,

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.browse
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * @suppress
  */
+@JsonClass(generateAdapter = true)
 data class BrowseResultLoadRequestBody(
         @Json(name = "filter_name") val filterName: String,
         @Json(name = "filter_value") val filterValue: String,

--- a/library/src/main/java/io/constructor/data/model/browse/Collection.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/Collection.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.browse
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models a collection response
  */
+@JsonClass(generateAdapter = true)
 data class Collection(
         @Json(name = "data") val data: Map<String, Any>?,
         @Json(name = "display_name") val displayName: String,

--- a/library/src/main/java/io/constructor/data/model/common/FilterFacet.kt
+++ b/library/src/main/java/io/constructor/data/model/common/FilterFacet.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models facet filters available for a response
  */
+@JsonClass(generateAdapter = true)
 data class FilterFacet(
        @Json(name = "display_name") val displayName: String?,
        @Json(name = "name") val name: String,

--- a/library/src/main/java/io/constructor/data/model/common/FilterFacetOption.kt
+++ b/library/src/main/java/io/constructor/data/model/common/FilterFacetOption.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models facet filter options available for a response
  */
+@JsonClass(generateAdapter = true)
 data class FilterFacetOption(
         @Json(name = "count") val count: Int,
         @Json(name = "display_name") val displayName: String?,

--- a/library/src/main/java/io/constructor/data/model/common/FilterGroup.kt
+++ b/library/src/main/java/io/constructor/data/model/common/FilterGroup.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models group filters available for a response
  */
+@JsonClass(generateAdapter = true)
 data class FilterGroup(
         @Json(name = "children") val children: List<FilterGroup>?,
         @Json(name = "parents") val parents: List<FilterGroup>?,

--- a/library/src/main/java/io/constructor/data/model/common/FilterSortOption.kt
+++ b/library/src/main/java/io/constructor/data/model/common/FilterSortOption.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models sorting options available for a response
  */
+@JsonClass(generateAdapter = true)
 data class FilterSortOption(
         @Json(name = "display_name") val displayName: String,
         @Json(name = "sort_by") val sortBy: String,

--- a/library/src/main/java/io/constructor/data/model/common/Result.kt
+++ b/library/src/main/java/io/constructor/data/model/common/Result.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models an individual item in a response as well as its variations
  */
+@JsonClass(generateAdapter = true)
 data class Result(
         @Json(name = "data") val data: ResultData,
         @Json(name = "matched_terms") val matchedTerms: List<String>?,

--- a/library/src/main/java/io/constructor/data/model/common/ResultData.kt
+++ b/library/src/main/java/io/constructor/data/model/common/ResultData.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models item metadata
  */
+@JsonClass(generateAdapter = true)
 data class ResultData(
         @Json(name = "description") val description: String?,
         @Json(name = "id") val id: String?,

--- a/library/src/main/java/io/constructor/data/model/common/ResultFacet.kt
+++ b/library/src/main/java/io/constructor/data/model/common/ResultFacet.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models facets on an item
  */
+@JsonClass(generateAdapter = true)
 data class ResultFacet(
         @Json(name = "name") val name: String,
         @Json(name = "values") val values: List<String>?

--- a/library/src/main/java/io/constructor/data/model/common/ResultGroup.kt
+++ b/library/src/main/java/io/constructor/data/model/common/ResultGroup.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models groups on an item
  */
+@JsonClass(generateAdapter = true)
 data class ResultGroup(
         @Json(name="display_name") var displayName: String?,
         @Json(name="group_id") var groupId: String,

--- a/library/src/main/java/io/constructor/data/model/common/ResultSources.kt
+++ b/library/src/main/java/io/constructor/data/model/common/ResultSources.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models result sources
  */
+@JsonClass(generateAdapter = true)
 data class ResultSources(
     @Json(name = "token_match") val tokenMatch: ResultSourcesData?,
     @Json(name = "embeddings_match") val embeddingsMatch: ResultSourcesData?,

--- a/library/src/main/java/io/constructor/data/model/common/ResultSourcesData.kt
+++ b/library/src/main/java/io/constructor/data/model/common/ResultSourcesData.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models result sources data
  */
+@JsonClass(generateAdapter = true)
 data class ResultSourcesData(
     @Json(name = "count") val count: Int?,
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/common/VariationsMap.kt
+++ b/library/src/main/java/io/constructor/data/model/common/VariationsMap.kt
@@ -1,13 +1,15 @@
 package io.constructor.data.model.common
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models variations map object available for modifying the request
  */
-data class VariationsMap(
- @Json(name = "dtype") val dtype: String,
- @Json(name = "values") val values: Map<String, Map<String, String>>,
- @Json(name = "group_by") val groupBy: List<Map<String, String>>? = null,
+@JsonClass(generateAdapter = true)
+data class VariationsMap constructor(
+    @Json(name = "dtype") val dtype: String,
+    @Json(name = "values") val values: Map<String, Map<String, String>>,
+    @Json(name = "group_by") val groupBy: List<Map<String, String>>? = null,
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/conversion/ConversionRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/conversion/ConversionRequestBody.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.conversion
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * @suppress
  */
+@JsonClass(generateAdapter = true)
 data class ConversionRequestBody(
         @Json(name = "search_term") val searchTerm: String,
         @Json(name = "item_id") val itemID: String,

--- a/library/src/main/java/io/constructor/data/model/purchase/PurchaseItem.kt
+++ b/library/src/main/java/io/constructor/data/model/purchase/PurchaseItem.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.purchase
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * @suppress
  */
+@JsonClass(generateAdapter = true)
 data class PurchaseItem(
         @Json(name = "item_id") val itemId: String?,
         @Json(name = "variation_id") val variationId: String? = null

--- a/library/src/main/java/io/constructor/data/model/purchase/PurchaseRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/purchase/PurchaseRequestBody.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.purchase
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * @suppress
  */
+@JsonClass(generateAdapter = true)
 data class PurchaseRequestBody(
         @Json(name = "items") val items: List<PurchaseItem>?,
         @Json(name = "order_id") val orderId: String,

--- a/library/src/main/java/io/constructor/data/model/recommendations/Pod.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/Pod.kt
@@ -1,8 +1,10 @@
 package io.constructor.data.model.recommendations
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
+@JsonClass(generateAdapter = true)
 data class Pod(
         @Json(name = "id") val response: String?,
         @Json(name = "display_name") val resultId: String?

--- a/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultClickRequestBody.kt
@@ -1,9 +1,11 @@
 package io.constructor.data.model.recommendations
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
+@JsonClass(generateAdapter = true)
 data class RecommendationResultClickRequestBody(
         @Json(name = "pod_id") val podId: String,
         @Json(name = "strategy_id") val strategyId: String,

--- a/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultViewRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultViewRequestBody.kt
@@ -1,9 +1,11 @@
 package io.constructor.data.model.recommendations
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
+@JsonClass(generateAdapter = true)
 data class RecommendationResultViewRequestBody(
         @Json(name = "pod_id") val podId: String,
         @Json(name = "num_results_viewed") val numResultsViewed: Int,

--- a/library/src/main/java/io/constructor/data/model/recommendations/RecommendationsResponse.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/RecommendationsResponse.kt
@@ -1,8 +1,10 @@
 package io.constructor.data.model.recommendations
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
+@JsonClass(generateAdapter = true)
 data class RecommendationsResponse(
         @Json(name = "response") val response: RecommendationsResponseInner?,
         @Json(name = "result_id") val resultId: String?,

--- a/library/src/main/java/io/constructor/data/model/recommendations/RecommendationsResponseInner.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/RecommendationsResponseInner.kt
@@ -1,9 +1,11 @@
 package io.constructor.data.model.recommendations
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
+@JsonClass(generateAdapter = true)
 data class RecommendationsResponseInner(
         @Json(name = "pod") val pod: Pod?,
         @Json(name = "results") val results: List<Result>?,

--- a/library/src/main/java/io/constructor/data/model/search/Redirect.kt
+++ b/library/src/main/java/io/constructor/data/model/search/Redirect.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.search
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models search redirects
  */
+@JsonClass(generateAdapter = true)
 data class Redirect(
         @Json(name = "data") val data: RedirectData,
         @Json(name = "matched_terms") val matchedTerms: List<String>?,

--- a/library/src/main/java/io/constructor/data/model/search/RedirectData.kt
+++ b/library/src/main/java/io/constructor/data/model/search/RedirectData.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.search
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models search redirect metadata
  */
+@JsonClass(generateAdapter = true)
 data class RedirectData(
         @Json(name = "url") val url: String?,
         @Json(name = "rule_id") val rule_id: Int?,

--- a/library/src/main/java/io/constructor/data/model/search/SearchResponse.kt
+++ b/library/src/main/java/io/constructor/data/model/search/SearchResponse.kt
@@ -1,11 +1,13 @@
 package io.constructor.data.model.search
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import java.io.Serializable
 
 /**
  * Models search response
  */
+@JsonClass(generateAdapter = true)
 data class SearchResponse(
         @Json(name = "response") val response: SearchResponseInner?,
         @Json(name = "result_id") val resultId: String?,

--- a/library/src/main/java/io/constructor/data/model/search/SearchResponseInner.kt
+++ b/library/src/main/java/io/constructor/data/model/search/SearchResponseInner.kt
@@ -1,12 +1,14 @@
 package io.constructor.data.model.search;
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 import io.constructor.data.model.common.*;
 import java.io.Serializable
 
 /**
  * Models search response details
  */
+@JsonClass(generateAdapter = true)
 data class SearchResponseInner(
         @Json(name = "facets") val facets: List<FilterFacet>?,
         @Json(name = "groups") val groups: List<FilterGroup>?,

--- a/library/src/main/java/io/constructor/injection/ConstructorSdk.kt
+++ b/library/src/main/java/io/constructor/injection/ConstructorSdk.kt
@@ -1,0 +1,8 @@
+package io.constructor.injection
+
+import javax.inject.Qualifier
+
+/**
+ * Prevents unintentional leakage of Constructor.io instances into the user's dependency graph.
+ */
+@Qualifier @Retention annotation class ConstructorSdk

--- a/library/src/main/java/io/constructor/injection/module/ApiModule.kt
+++ b/library/src/main/java/io/constructor/injection/module/ApiModule.kt
@@ -10,7 +10,7 @@ import javax.inject.Singleton
  * @suppress
  */
 @Module(includes = [(NetworkModule::class)])
-class ApiModule {
+object ApiModule {
 
     @Provides
     @Singleton

--- a/library/src/main/java/io/constructor/injection/module/AppModule.kt
+++ b/library/src/main/java/io/constructor/injection/module/AppModule.kt
@@ -1,11 +1,13 @@
 package io.constructor.injection.module
 
 import android.content.Context
+import android.content.SharedPreferences
 import dagger.Module
 import dagger.Provides
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.injection.ApplicationContext
+import io.constructor.injection.ConstructorSdk
 import javax.inject.Singleton
 
 /**
@@ -21,8 +23,14 @@ class AppModule(private val application: Context) {
     }
 
     @Provides
-    internal fun providePreferenceHelper(@ApplicationContext context: Context): PreferencesHelper {
-        return PreferencesHelper(context)
+    internal fun providePreferenceHelper(@ConstructorSdk preferences: SharedPreferences): PreferencesHelper {
+        return PreferencesHelper(preferences)
+    }
+
+    @Provides
+    @ConstructorSdk
+    internal fun provideConfigPreferences(@ApplicationContext context: Context): SharedPreferences {
+        return context.getSharedPreferences("constructor_pref_file", Context.MODE_PRIVATE)
     }
 
     @Provides

--- a/library/src/main/java/io/constructor/injection/module/NetworkModule.kt
+++ b/library/src/main/java/io/constructor/injection/module/NetworkModule.kt
@@ -1,7 +1,6 @@
 package io.constructor.injection.module
 
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import io.constructor.BuildConfig
@@ -72,6 +71,5 @@ object NetworkModule {
     internal fun provideMoshi(): Moshi = Moshi
         .Builder()
         .add(ResultDataAdapter())
-        .add(KotlinJsonAdapterFactory())
         .build()
 }

--- a/library/src/main/java/io/constructor/injection/module/NetworkModule.kt
+++ b/library/src/main/java/io/constructor/injection/module/NetworkModule.kt
@@ -1,8 +1,7 @@
 package io.constructor.injection.module
 
-import android.content.Context
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import io.constructor.BuildConfig
@@ -10,6 +9,7 @@ import io.constructor.data.interceptor.RequestInterceptor
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.data.model.dataadapter.ResultDataAdapter
+import io.constructor.injection.ConstructorSdk
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -21,22 +21,29 @@ import javax.inject.Singleton
  * @suppress
  */
 @Module
-class NetworkModule(private val context: Context) {
+object NetworkModule {
 
     @Provides
     @Singleton
-    internal fun provideRetrofit(okHttpClient: OkHttpClient, moshi: Moshi, preferencesHelper: PreferencesHelper): Retrofit =
-            Retrofit.Builder()
-                    .baseUrl(preferencesHelper.scheme + "://" + preferencesHelper.serviceUrl)
-                    .client(okHttpClient)
-                    .addConverterFactory(MoshiConverterFactory.create(moshi))
-                    .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-                    .build()
+    internal fun provideRetrofit(
+        @ConstructorSdk okHttpClient: OkHttpClient,
+        @ConstructorSdk moshi: Moshi,
+        preferencesHelper: PreferencesHelper
+    ): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(preferencesHelper.scheme + "://" + preferencesHelper.serviceUrl)
+            .client(okHttpClient)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .build()
 
     @Provides
     @Singleton
-    internal fun provideOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor,
-                                     requestInterceptor: RequestInterceptor): OkHttpClient {
+    @ConstructorSdk
+    internal fun provideOkHttpClient(
+        @ConstructorSdk httpLoggingInterceptor: HttpLoggingInterceptor,
+        requestInterceptor: RequestInterceptor
+    ): OkHttpClient {
         val httpClientBuilder = OkHttpClient.Builder()
         httpClientBuilder.addInterceptor(requestInterceptor)
         if (BuildConfig.DEBUG) {
@@ -48,18 +55,23 @@ class NetworkModule(private val context: Context) {
 
     @Provides
     @Singleton
+    @ConstructorSdk
     internal fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor =
-            HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BASIC)
+        HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BASIC)
 
     @Provides
     @Singleton
-    internal fun provideRequestInterceptor(prefHelper: PreferencesHelper, configMemoryHolder: ConfigMemoryHolder): RequestInterceptor = RequestInterceptor(context, prefHelper, configMemoryHolder)
+    internal fun provideRequestInterceptor(
+        prefHelper: PreferencesHelper,
+        configMemoryHolder: ConfigMemoryHolder
+    ): RequestInterceptor = RequestInterceptor(prefHelper, configMemoryHolder)
 
     @Provides
     @Singleton
+    @ConstructorSdk
     internal fun provideMoshi(): Moshi = Moshi
-            .Builder()
-            .add(ResultDataAdapter())
-            .add(KotlinJsonAdapterFactory())
-            .build()
+        .Builder()
+        .add(ResultDataAdapter())
+        .add(KotlinJsonAdapterFactory())
+        .build()
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -57,7 +58,8 @@ class ConstructorIoAutocompleteTest {
 
     @Test
     fun getAutocompleteResults() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getAutocompleteResults("titanic").test()
         observer.assertComplete().assertValue {
@@ -65,28 +67,34 @@ class ConstructorIoAutocompleteTest {
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithFacetFilter() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val facet = hashMapOf("storeLocation" to listOf("CA"))
-        val observer = constructorIo.getAutocompleteResults("titanic", facet?.map { it.key to it.value }).test()
+        val observer =
+            constructorIo.getAutocompleteResults("titanic", facet?.map { it.key to it.value })
+                .test()
         observer.assertComplete().assertValue {
             var suggestions = it.get()!!.sections?.get("Search Suggestions");
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithGroupIdFilter() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getAutocompleteResults("titanic", null, 101).test()
         observer.assertComplete().assertValue {
@@ -94,7 +102,8 @@ class ConstructorIoAutocompleteTest {
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
@@ -107,13 +116,15 @@ class ConstructorIoAutocompleteTest {
             it.networkError
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithTimeout() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockResponse.throttleBody(128, 5, TimeUnit.SECONDS)
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getAutocompleteResults("titanic").test()
@@ -121,13 +132,15 @@ class ConstructorIoAutocompleteTest {
             it.isError
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithEmptyResponse() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response_empty.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response_empty.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getAutocompleteResults("titanic").test()
         observer.assertComplete().assertValue {
@@ -135,33 +148,44 @@ class ConstructorIoAutocompleteTest {
             suggestions?.isEmpty()!!
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithHiddenFields() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getAutocompleteResults("bbq", null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getAutocompleteResults(
+            "bbq",
+            null,
+            null,
+            listOf("hiddenField1", "hiddenField2")
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/bbq?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/bbq?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithProperUrlEncoding() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getAutocompleteResults("2% cheese").test()
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/2%25%20cheese?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/2%25%20cheese?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithFiltersUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val filters = mapOf(
             "storeLocation" to listOf("CA"),
@@ -176,46 +200,76 @@ class ConstructorIoAutocompleteTest {
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?filters%5BstoreLocation%5D=CA&filters%5Bgroup_id%5D=101&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithNumResultsPerSectionUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
         val numResultsPerSection = mapOf(
             "Products" to 5,
             "Search Suggestions" to 10,
         )
         val autocompleteRequest = AutocompleteRequest.Builder("titanic")
-                .setNumResultsPerSection(numResultsPerSection)
-                .build()
+            .setNumResultsPerSection(numResultsPerSection)
+            .build()
         val observer = constructorIo.getAutocompleteResults(autocompleteRequest).test()
         observer.assertComplete().assertValue {
             var suggestions = it.get()!!.sections?.get("Search Suggestions");
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?num_results_Products=5&num_results_Search%20Suggestions=10&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
+        val path =
+            "/autocomplete/titanic?num_results_Products=5&num_results_Search%20Suggestions=10&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getAutocompleteResultsWithVariationsMapUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
         mockServer.enqueue(mockResponse)
-        val variationsMap = VariationsMap("array", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")), listOf(mapOf("name" to "Country", "field" to "data.facets.Country")))
+        val variationsMap = VariationsMap(
+            dtype = "array",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            ),
+            groupBy = listOf(mapOf("name" to "Country", "field" to "data.facets.Country"))
+        )
         val autocompleteRequest = AutocompleteRequest.Builder("titanic")
-                .setVariationsMap(variationsMap)
-                .build()
+            .setVariationsMap(variationsMap)
+            .build()
         val observer = constructorIo.getAutocompleteResults(autocompleteRequest).test()
         observer.assertComplete().assertValue {
             var suggestions = it.get()!!.sections?.get("Search Suggestions");
             suggestions?.isNotEmpty()!! && suggestions.size == 5
         }
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic?variations_map=%7B%22dtype%22%3A%22array%22%2C%22group_by%22%3A%5B%7B%22name%22%3A%22Country%22%2C%22field%22%3A%22data.facets.Country%22%7D%5D%2C%22values%22%3A%7B%22Price%22%3A%7B%22aggregation%22%3A%22min%22%2C%22field%22%3A%22data.facets.price%22%7D%2C%22Country%22%3A%7B%22aggregation%22%3A%22all%22%2C%22field%22%3A%22data.facets.country%22%7D%7D%7D&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.17.1&_dt="
-        assert(request.path!!.startsWith(path))
+        assertThat(request.requestUrl!!.encodedPath).isEqualTo("/autocomplete/titanic")
+        with(request.requestUrl!!) {
+            val queryParams = mapOf(
+                "variations_map" to """{"dtype":"array","values":{"Price":{"aggregation":"min","field":"data.facets.price"},"Country":{"aggregation":"all","field":"data.facets.country"}},"group_by":[{"name":"Country","field":"data.facets.Country"}]}""",
+                "key" to "golden-key",
+                "i" to "guido-the-guid",
+                "ui" to "player-one",
+                "s" to "79",
+                "c" to "cioand-2.17.1",
+                "_dt" to "1"
+            )
+            assertThat(queryParameterNames).containsExactlyInAnyOrderElementsOf(queryParams.keys)
+
+            queryParams.forEach { (key, value) ->
+                if (key == "_dt") {
+                    assertThat(queryParameter(key)).containsOnlyDigits()
+                } else {
+                    assertThat(queryParameter(key)).isEqualTo(value)
+                }
+            }
+        }
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -50,7 +50,7 @@ class ConstructorIoAutocompleteTest {
         every { configMemoryHolder.segments } returns emptyList()
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -45,7 +45,7 @@ class ConstructorIoIntegrationTest {
         every { configMemoryHolder.segments } returns emptyList()
 
         val config = ConstructorIoConfig("key_K2hlXt5aVSwoI1Uw")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -19,7 +19,8 @@ import org.junit.Test
 class ConstructorIoIntegrationTest {
 
     @Rule
-    @JvmField val overrideSchedulersRule = RxSchedulersOverrideRule()
+    @JvmField
+    val overrideSchedulersRule = RxSchedulersOverrideRule()
 
     private var constructorIo = ConstructorIo
     private val ctx = mockk<Context>()
@@ -63,7 +64,8 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getAutocompleteResultsWithFiltersAgainstRealResponse() {
         val facet = hashMapOf("storeLocation" to listOf("CA"))
-        val observer = constructorIo.getAutocompleteResults("pork", facet?.map { it.key to it.value }).test()
+        val observer =
+            constructorIo.getAutocompleteResults("pork", facet?.map { it.key to it.value }).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -98,7 +100,8 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getSearchResultsWithFiltersAgainstRealResponse() {
         val facet = hashMapOf("storeLocation" to listOf("CA"))
-        val observer = constructorIo.getSearchResults("pork", facet?.map { it.key to it.value }).test()
+        val observer =
+            constructorIo.getSearchResults("pork", facet?.map { it.key to it.value }).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -120,14 +123,18 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getBrowseResultsWithFiltersAgainstRealResponse() {
         val facet = hashMapOf("storeLocation" to listOf("CA"))
-        val observer = constructorIo.getBrowseResults("group_ids", "544", facet?.map { it.key to it.value }).test()
+        val observer =
+            constructorIo.getBrowseResults("group_ids", "544", facet?.map { it.key to it.value })
+                .test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
 
     @Test
     fun trackAutocompleteSelectAgainstRealResponse() {
-        val observer = constructorIo.trackAutocompleteSelectInternal("pork", "pork", "Search Suggestions").test()
+        val observer =
+            constructorIo.trackAutocompleteSelectInternal("pork", "pork", "Search Suggestions")
+                .test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -141,21 +148,34 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun trackSearchResultClickAgainstRealResponse() {
-        val observer = constructorIo.trackSearchResultClickInternal("Boneless Pork Shoulder Roast", "prrst_shldr_bls", "pork").test()
+        val observer = constructorIo.trackSearchResultClickInternal(
+            "Boneless Pork Shoulder Roast",
+            "prrst_shldr_bls",
+            "pork"
+        ).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
 
     @Test
     fun trackConversionAgainstRealResponse() {
-        val observer = constructorIo.trackConversionInternal("Boneless Pork Shoulder Roast", "prrst_shldr_bls", 1.99).test()
+        val observer = constructorIo.trackConversionInternal(
+            "Boneless Pork Shoulder Roast",
+            "prrst_shldr_bls",
+            1.99
+        ).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
 
     @Test
     fun trackPurchaseAgainstRealResponse() {
-        val observer = constructorIo.trackPurchaseInternal(arrayOf("prrst_shldr_bls", "prrst_crwn"), 9.98, "45273", "Products").test()
+        val observer = constructorIo.trackPurchaseInternal(
+            arrayOf("prrst_shldr_bls", "prrst_crwn"),
+            9.98,
+            "45273",
+            "Products"
+        ).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -169,7 +189,9 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun trackBrowseResultClickAgainstRealResponse() {
-        val observer = constructorIo.trackBrowseResultClickInternal("group_ids", "544", "prrst_shldr_bls", 5).test()
+        val observer =
+            constructorIo.trackBrowseResultClickInternal("group_ids", "544", "prrst_shldr_bls", 5)
+                .test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -188,7 +210,11 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun trackRecommendationResultClickAgainstRealResponse() {
-        val observer = constructorIo.trackRecommendationResultClickInternal("pdp5", "User Featured", "prrst_shldr_bls").test()
+        val observer = constructorIo.trackRecommendationResultClickInternal(
+            "pdp5",
+            "User Featured",
+            "prrst_shldr_bls"
+        ).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -207,8 +233,10 @@ class ConstructorIoIntegrationTest {
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.sections!!.isNotEmpty()
-            it.get()?.sections?.get("Products")?.first()?.data?.metadata?.get("hiddenField1") !== null
-            it.get()?.sections?.get("Products")?.first()?.data?.metadata?.get("hiddenField2") !== null
+            it.get()?.sections?.get("Products")
+                ?.first()?.data?.metadata?.get("hiddenField1") !== null
+            it.get()?.sections?.get("Products")
+                ?.first()?.data?.metadata?.get("hiddenField2") !== null
         }
         Thread.sleep(timeBetweenTests)
     }
@@ -216,7 +244,17 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getSearchResultsWithHiddenFieldsAgainstRealResponse() {
         val hiddenFields = listOf("hiddenField1", "hiddenField2")
-        val observer = constructorIo.getSearchResults("pork", null, null, null, null, null, null, null, hiddenFields).test()
+        val observer = constructorIo.getSearchResults(
+            "pork",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            hiddenFields
+        ).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.response?.results!!.isNotEmpty()
@@ -229,11 +267,23 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getSearchResultsWithHiddenFacetsAgainstRealResponse() {
         val hiddenFacets = listOf("Brand")
-        val observer = constructorIo.getSearchResults("pork", null, null, null, null, null, null, null, null, hiddenFacets).test()
+        val observer = constructorIo.getSearchResults(
+            "pork",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            hiddenFacets
+        ).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.response?.facets!!.isNotEmpty()
-            val brandFacet = it.get()?.response?.facets?.find { facet -> facet.name.contains("Brand") }
+            val brandFacet =
+                it.get()?.response?.facets?.find { facet -> facet.name.contains("Brand") }
             brandFacet !== null
         }
         Thread.sleep(timeBetweenTests)
@@ -272,7 +322,18 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getBrowseResultsWithHiddenFieldsAgainstRealResponse() {
         val hiddenFields = listOf("hiddenField1", "hiddenField2")
-        val observer = constructorIo.getBrowseResults("group_id", "431", null, null, null, null, null, null, null, hiddenFields).test()
+        val observer = constructorIo.getBrowseResults(
+            "group_id",
+            "431",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            hiddenFields
+        ).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.response?.results!!.isNotEmpty()
@@ -285,11 +346,24 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getBrowseResultsWithHiddenFacetsAgainstRealResponse() {
         val hiddenFacets = listOf("Brand")
-        val observer = constructorIo.getBrowseResults("group_id", "431", null, null, null, null, null, null, null, null, hiddenFacets).test()
+        val observer = constructorIo.getBrowseResults(
+            "group_id",
+            "431",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            hiddenFacets
+        ).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.response?.facets!!.isNotEmpty()
-            val brandFacet = it.get()?.response?.facets?.find { facet -> facet.name.contains("Brand") }
+            val brandFacet =
+                it.get()?.response?.facets?.find { facet -> facet.name.contains("Brand") }
             brandFacet !== null
         }
         Thread.sleep(timeBetweenTests)
@@ -319,13 +393,21 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getAutocompleteResultsAgainstRealResponseWithVariationsMapArrayUsingRequestBuilder() {
-        val variationsMap = VariationsMap("array", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")))
-        val request = AutocompleteRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
+        val variationsMap = VariationsMap(
+            dtype = "array",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            )
+        )
+        val request =
+            AutocompleteRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getAutocompleteResults(request).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.sections!!.isNotEmpty()
-            val returnedVariationsMap = it.get()?.sections!!["Products"]?.get(0)?.variationsMap as List<*>
+            val returnedVariationsMap =
+                it.get()?.sections!!["Products"]?.get(0)?.variationsMap as List<*>
             returnedVariationsMap.isNotEmpty()
         }
         Thread.sleep(timeBetweenTests)
@@ -333,13 +415,21 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getAutocompleteResultsAgainstRealResponseWithVariationsMapObjectUsingRequestBuilder() {
-        val variationsMap = VariationsMap("object", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")))
-        val request = AutocompleteRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
+        val variationsMap = VariationsMap(
+            dtype = "object",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            )
+        )
+        val request =
+            AutocompleteRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getAutocompleteResults(request).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
             it.get()?.sections!!.isNotEmpty()
-            val returnedVariationsMap = it.get()?.sections!!["Products"]?.get(0)?.variationsMap as Map<*, *>
+            val returnedVariationsMap =
+                it.get()?.sections!!["Products"]?.get(0)?.variationsMap as Map<*, *>
             returnedVariationsMap.isNotEmpty()
         }
         Thread.sleep(timeBetweenTests)
@@ -362,7 +452,13 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getSearchResultAgainstRealResponseWithVariationsMapArrayUsingRequestBuilder() {
-        val variationsMap = VariationsMap("array", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")))
+        val variationsMap = VariationsMap(
+            dtype = "array",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            )
+        )
         val request = SearchRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getSearchResults(request).test()
         observer.assertComplete().assertValue {
@@ -380,7 +476,13 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getSearchResultAgainstRealResponseWithVariationsMapObjectUsingRequestBuilder() {
-        val variationsMap = VariationsMap("object", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")))
+        val variationsMap = VariationsMap(
+            dtype = "object",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            )
+        )
         val request = SearchRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getSearchResults(request).test()
         observer.assertComplete().assertValue {
@@ -430,8 +532,15 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getBrowseResultAgainstRealResponseWithVariationsArrayMapUsingRequestBuilder() {
-        val variationsMap = VariationsMap("array", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")))
-        val request = BrowseRequest.Builder("group_id", "544").setVariationsMap(variationsMap).build()
+        val variationsMap = VariationsMap(
+            dtype = "array",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            )
+        )
+        val request =
+            BrowseRequest.Builder("group_id", "544").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getBrowseResults(request).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
@@ -448,8 +557,15 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getBrowseResultAgainstRealResponseWithVariationsObjectMapUsingRequestBuilder() {
-        val variationsMap = VariationsMap("object", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")))
-        val request = BrowseRequest.Builder("group_id", "431").setVariationsMap(variationsMap).build()
+        val variationsMap = VariationsMap(
+            dtype = "object",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            )
+        )
+        val request =
+            BrowseRequest.Builder("group_id", "431").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getBrowseResults(request).test()
         observer.assertComplete().assertValue {
             it.get()?.resultId !== null
@@ -458,7 +574,7 @@ class ConstructorIoIntegrationTest {
             it.get()?.response?.groups!!.isNotEmpty()
             it.get()?.response?.filterSortOptions!!.isNotEmpty()
             it.get()?.response?.resultCount!! > 0
-            val returnedVariationsMap = it.get()?.response?.results!![0].variationsMap as? Map<*,*>
+            val returnedVariationsMap = it.get()?.response?.results!![0].variationsMap as? Map<*, *>
             returnedVariationsMap!!.isNotEmpty()
         }
         Thread.sleep(timeBetweenTests)

--- a/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
@@ -49,7 +49,7 @@ class ConstructorIoRecommendationsTest {
         every { configMemoryHolder.segments } returns emptyList()
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -100,7 +100,7 @@ class ConstructorIoTrackingTest {
         every { configMemoryHolder.segments } returns emptyList()
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -50,7 +50,7 @@ class ConstructorIoBrowseTest {
         every { configMemoryHolder.segments } returns emptyList()
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -57,7 +58,8 @@ class ConstructorIoBrowseTest {
 
     @Test
     fun getBrowseResults() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getBrowseResults("group_id", "Beverages").test()
         observer.assertComplete().assertValue {
@@ -73,7 +75,8 @@ class ConstructorIoBrowseTest {
             it.get()!!.response?.resultCount == 367
         }
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
+        val path =
+            "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
         assert(request.path!!.startsWith(path))
     }
 
@@ -86,13 +89,15 @@ class ConstructorIoBrowseTest {
             it.networkError
         }
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
+        val path =
+            "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithTimeout() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockResponse.throttleBody(128, 5, TimeUnit.SECONDS)
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getBrowseResults("group_id", "Beverages").test()
@@ -100,13 +105,15 @@ class ConstructorIoBrowseTest {
             it.isError
         }
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
+        val path =
+            "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithEmptyResponse() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response_empty.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response_empty.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getBrowseResults("group_id", "Beverages").test()
         observer.assertComplete().assertValue {
@@ -116,75 +123,140 @@ class ConstructorIoBrowseTest {
             it.get()!!.response?.resultCount == 0
         }
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
+        val path =
+            "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithSection() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, "Sold Out").test()
+        val observer = constructorIo.getBrowseResults(
+            "group_id",
+            "Beverages",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "Sold Out"
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
+        val path =
+            "/browse/group_id/Beverages?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt"
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithFacets() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val facets = listOf(Pair("Brand", listOf("Signature Farms", "Del Monte")), Pair("Nutrition", listOf("Organic")))
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", facets, null, null , null, null, null, null).test()
+        val facets = listOf(
+            Pair("Brand", listOf("Signature Farms", "Del Monte")),
+            Pair("Nutrition", listOf("Organic"))
+        )
+        val observer = constructorIo.getBrowseResults(
+            "group_id",
+            "Beverages",
+            facets,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithHiddenFields() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getBrowseResults(
+            "group_id",
+            "Beverages",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            listOf("hiddenField1", "hiddenField2")
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/group_id/Beverages?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithHiddenFacets() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
         val hiddenFacets = listOf("Brand", "price_US")
-        val observer = constructorIo.getBrowseResults("group_id", "Beverages", null, null, null, null, null, null, null, null, hiddenFacets).test()
+        val observer = constructorIo.getBrowseResults(
+            "group_id",
+            "Beverages",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            hiddenFacets
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?fmt_options%5Bhidden_facets%5D=Brand&fmt_options%5Bhidden_facets%5D=price_US&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/group_id/Beverages?fmt_options%5Bhidden_facets%5D=Brand&fmt_options%5Bhidden_facets%5D=price_US&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithCollection() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getBrowseResults("collection_id", "test-collection").test()
         val request = mockServer.takeRequest()
-        val path = "/browse/collection_id/test-collection?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/collection_id/test-collection?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultWithGroupsSort() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getBrowseResults(filterName = "group_id", filterValue = "Beverages", groupsSortBy = "value", groupsSortOrder = "ascending").test()
+        val observer = constructorIo.getBrowseResults(
+            filterName = "group_id",
+            filterValue = "Beverages",
+            groupsSortBy = "value",
+            groupsSortOrder = "ascending"
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithFiltersUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
         val filters = mapOf(
             "Brand" to listOf("Signature Farms", "Del Monte"),
@@ -195,13 +267,15 @@ class ConstructorIoBrowseTest {
             .build()
         val observer = constructorIo.getBrowseResults(browseRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/group_id/Beverages?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithGroupsSortUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
         val browseRequest = BrowseRequest.Builder("group_id", "Beverages")
             .setGroupsSortBy("value")
@@ -209,21 +283,49 @@ class ConstructorIoBrowseTest {
             .build()
         val observer = constructorIo.getBrowseResults(browseRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/browse/group_id/Beverages?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getBrowseResultsWithVariationsMapsUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("browse_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
-        val variationsMap = VariationsMap("array", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")), listOf(mapOf("name" to "Country", "field" to "data.facets.Country")))
+        val variationsMap = VariationsMap(
+            dtype = "array",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            ),
+            groupBy = listOf(mapOf("name" to "Country", "field" to "data.facets.Country"))
+        )
         val browseRequest = BrowseRequest.Builder("group_id", "Beverages")
-                .setVariationsMap(variationsMap)
-                .build()
+            .setVariationsMap(variationsMap)
+            .build()
         val observer = constructorIo.getBrowseResults(browseRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/browse/group_id/Beverages?variations_map=%7B%22dtype%22%3A%22array%22%2C%22group_by%22%3A%5B%7B%22name%22%3A%22Country%22%2C%22field%22%3A%22data.facets.Country%22%7D%5D%2C%22values%22%3A%7B%22Price%22%3A%7B%22aggregation%22%3A%22min%22%2C%22field%22%3A%22data.facets.price%22%7D%2C%22Country%22%3A%7B%22aggregation%22%3A%22all%22%2C%22field%22%3A%22data.facets.country%22%7D%7D%7D&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
-        assert(request.path!!.startsWith(path))
+        assertThat(request.requestUrl!!.encodedPath).isEqualTo("/browse/group_id/Beverages")
+        with(request.requestUrl!!) {
+            val queryParams = mapOf(
+                "variations_map" to """{"dtype":"array","values":{"Price":{"aggregation":"min","field":"data.facets.price"},"Country":{"aggregation":"all","field":"data.facets.country"}},"group_by":[{"name":"Country","field":"data.facets.Country"}]}""",
+                "key" to "silver-key",
+                "i" to "guapo-the-guid",
+                "ui" to "player-two",
+                "s" to "92",
+                "c" to "cioand-2.17.1",
+                "_dt" to "1"
+            )
+            assertThat(queryParameterNames).containsExactlyInAnyOrderElementsOf(queryParams.keys)
+
+            queryParams.forEach { (key, value) ->
+                if (key == "_dt") {
+                    assertThat(queryParameter(key)).containsOnlyDigits()
+                } else {
+                    assertThat(queryParameter(key)).isEqualTo(value)
+                }
+            }
+        }
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -57,7 +58,8 @@ class ConstructorIoSearchTest {
 
     @Test
     fun getSearchResults() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("corn").test()
         observer.assertComplete().assertValue {
@@ -74,7 +76,8 @@ class ConstructorIoSearchTest {
             it.get()!!.response?.resultCount == 225
         }
         val request = mockServer.takeRequest()
-        val path = "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
@@ -87,13 +90,15 @@ class ConstructorIoSearchTest {
             it.networkError
         }
         val request = mockServer.takeRequest()
-        val path = "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithTimeout() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockResponse.throttleBody(128, 5, TimeUnit.SECONDS)
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("corn").test()
@@ -101,13 +106,15 @@ class ConstructorIoSearchTest {
             it.isError
         }
         val request = mockServer.takeRequest()
-        val path = "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithEmptyResponse() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response_empty.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response_empty.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("corn").test()
         observer.assertComplete().assertValue {
@@ -117,13 +124,15 @@ class ConstructorIoSearchTest {
             it.get()!!.response?.resultCount == 0
         }
         val request = mockServer.takeRequest()
-        val path = "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithRedirect() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response_redirect.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response_redirect.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("bbq").test()
         observer.assertComplete().assertValue {
@@ -131,114 +140,190 @@ class ConstructorIoSearchTest {
             it.get()!!.response?.redirect?.matchedTerms!![0] == "bbq"
         }
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/bbq?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithSection() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, "Sold Out").test()
+        val observer =
+            constructorIo.getSearchResults("bbq", null, null, null, null, null, null, "Sold Out")
+                .test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/bbq?section=Sold%20Out&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithFacets() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val facets = listOf(Pair("Brand", listOf("Signature Farms", "Del Monte")), Pair("Nutrition", listOf("Organic")))
-        val observer = constructorIo.getSearchResults("bbq", facets, null, null , null, null, null, null).test()
+        val facets = listOf(
+            Pair("Brand", listOf("Signature Farms", "Del Monte")),
+            Pair("Nutrition", listOf("Organic"))
+        )
+        val observer =
+            constructorIo.getSearchResults("bbq", facets, null, null, null, null, null, null).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1"
+        val path =
+            "/search/bbq?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1"
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithHiddenFields() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, listOf("hiddenField1", "hiddenField2")).test()
+        val observer = constructorIo.getSearchResults(
+            "bbq",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            listOf("hiddenField1", "hiddenField2")
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/bbq?fmt_options%5Bhidden_fields%5D=hiddenField1&fmt_options%5Bhidden_fields%5D=hiddenField2&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithHiddenFacets() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
         val hiddenFacets = listOf("Brand", "price_US")
-        val observer = constructorIo.getSearchResults("bbq", null, null, null , null, null, null, null, null, hiddenFacets).test()
+        val observer = constructorIo.getSearchResults(
+            "bbq",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            hiddenFacets
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?fmt_options%5Bhidden_facets%5D=Brand&fmt_options%5Bhidden_facets%5D=price_US&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/bbq?fmt_options%5Bhidden_facets%5D=Brand&fmt_options%5Bhidden_facets%5D=price_US&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithProperUrlEncoding() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("2% cheese").test()
         val request = mockServer.takeRequest()
-        val path = "/search/2%25%20cheese?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/2%25%20cheese?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithGroupsSort() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val observer = constructorIo.getSearchResults(term = "bbq", groupsSortBy = "value", groupsSortOrder = "descending").test()
+        val observer = constructorIo.getSearchResults(
+            term = "bbq",
+            groupsSortBy = "value",
+            groupsSortOrder = "descending"
+        ).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=descending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=descending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithFiltersUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
         val filters = mapOf(
-                "Brand" to listOf("Signature Farms", "Del Monte"),
-                "Nutrition" to listOf("Organic")
+            "Brand" to listOf("Signature Farms", "Del Monte"),
+            "Nutrition" to listOf("Organic")
         )
         val searchRequest = SearchRequest.Builder("bbq")
-                .setFilters(filters)
-                .build()
+            .setFilters(filters)
+            .build()
         val observer = constructorIo.getSearchResults(searchRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1"
+        val path =
+            "/search/bbq?filters%5BBrand%5D=Signature%20Farms&filters%5BBrand%5D=Del%20Monte&filters%5BNutrition%5D=Organic&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1"
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithGroupsSortUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
         val searchRequest = SearchRequest.Builder("bbq")
-                .setGroupsSortBy("value")
-                .setGroupsSortOrder("ascending")
-                .build()
+            .setGroupsSortBy("value")
+            .setGroupsSortOrder("ascending")
+            .build()
         val observer = constructorIo.getSearchResults(searchRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
+        val path =
+            "/search/bbq?fmt_options%5Bgroups_sort_by%5D=value&fmt_options%5Bgroups_sort_order%5D=ascending&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
         assert(request.path!!.startsWith(path))
     }
 
     @Test
     fun getSearchResultsWithVariationsMapUsingBuilder() {
-        val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("search_response.json"))
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
-        val variationsMap = VariationsMap("array", mapOf("Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"), "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")), listOf(mapOf("name" to "Country", "field" to "data.facets.Country")))
+        val variationsMap = VariationsMap(
+            dtype = "array",
+            values = mapOf(
+                "Price" to mapOf("aggregation" to "min", "field" to "data.facets.price"),
+                "Country" to mapOf("aggregation" to "all", "field" to "data.facets.country")
+            ),
+            groupBy = listOf(mapOf("name" to "Country", "field" to "data.facets.Country"))
+        )
         val searchRequest = SearchRequest.Builder("bbq")
-                .setVariationsMap(variationsMap)
-                .build()
+            .setVariationsMap(variationsMap)
+            .build()
         val observer = constructorIo.getSearchResults(searchRequest).test()
         val request = mockServer.takeRequest()
-        val path = "/search/bbq?variations_map=%7B%22dtype%22%3A%22array%22%2C%22group_by%22%3A%5B%7B%22name%22%3A%22Country%22%2C%22field%22%3A%22data.facets.Country%22%7D%5D%2C%22values%22%3A%7B%22Price%22%3A%7B%22aggregation%22%3A%22min%22%2C%22field%22%3A%22data.facets.price%22%7D%2C%22Country%22%3A%7B%22aggregation%22%3A%22all%22%2C%22field%22%3A%22data.facets.country%22%7D%7D%7D&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.17.1&_dt="
-        assert(request.path!!.startsWith(path))
+
+        assertThat(request.requestUrl!!.encodedPath).isEqualTo("/search/bbq")
+        with(request.requestUrl!!) {
+            val queryParams = mapOf(
+                "variations_map" to """{"dtype":"array","values":{"Price":{"aggregation":"min","field":"data.facets.price"},"Country":{"aggregation":"all","field":"data.facets.country"}},"group_by":[{"name":"Country","field":"data.facets.Country"}]}""",
+                "key" to "silver-key",
+                "i" to "guapo-the-guid",
+                "ui" to "player-two",
+                "s" to "92",
+                "c" to "cioand-2.17.1",
+                "_dt" to "1"
+            )
+            assertThat(queryParameterNames).containsExactlyInAnyOrderElementsOf(queryParams.keys)
+
+            queryParams.forEach { (key, value) ->
+                if (key == "_dt") {
+                    assertThat(queryParameter(key)).containsOnlyDigits()
+                } else {
+                    assertThat(queryParameter(key)).isEqualTo(value)
+                }
+            }
+        }
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -50,7 +50,7 @@ class ConstructorIoSearchTest {
         every { configMemoryHolder.segments } returns emptyList()
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
@@ -48,7 +48,7 @@ class ConstructorioSegmentsTest {
         every { configMemoryHolder.segments } returns  listOf("mobile", "COUNTRY_US")
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
@@ -49,7 +49,7 @@ class ConstructorioTestCellTest {
 
 
         val config = ConstructorIoConfig("dummyKey")
-        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder, ctx)
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
 
         constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
     }

--- a/library/src/test/java/io/constructor/data/local/PreferencesHelperTest.kt
+++ b/library/src/test/java/io/constructor/data/local/PreferencesHelperTest.kt
@@ -1,5 +1,7 @@
 package io.constructor.data.local
 
+import android.content.Context
+import android.content.SharedPreferences
 import io.mockk.every
 import io.mockk.spyk
 import org.junit.Assert.assertEquals
@@ -15,7 +17,10 @@ import java.util.concurrent.TimeUnit
 class PreferencesHelperTest {
 
     private val partyLikeIts1999 = 946684800000
-    private val preferencesHelper = spyk(PreferencesHelper(RuntimeEnvironment.application.applicationContext, "test.prefs"))
+    private val context: Context = RuntimeEnvironment.application.applicationContext
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences("test.prefs", Context.MODE_PRIVATE)
+    private val preferencesHelper = spyk(PreferencesHelper(sharedPreferences))
 
     @Test
     fun saveAndRetrieveId() {

--- a/library/src/test/java/io/constructor/test/helpers.kt
+++ b/library/src/test/java/io/constructor/test/helpers.kt
@@ -1,6 +1,5 @@
 package io.constructor.test
 
-import android.content.Context
 import io.constructor.data.DataManager
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
@@ -11,19 +10,18 @@ import java.util.concurrent.TimeUnit
 /**
  * Creates a data manager that communicates with a Mock Web Server
  */
-fun createTestDataManager(preferencesHelper: PreferencesHelper,
-                          configMemoryHolder: ConfigMemoryHolder,
-                          ctx: Context
+fun createTestDataManager(
+    preferencesHelper: PreferencesHelper,
+    configMemoryHolder: ConfigMemoryHolder
 ): DataManager {
-    val networkModule = NetworkModule(ctx);
-    val loggingInterceptor = networkModule.provideHttpLoggingInterceptor()
-    val requestInterceptor = networkModule.provideRequestInterceptor(preferencesHelper, configMemoryHolder)
-    val moshi = networkModule.provideMoshi()
-    val okHttpClient = networkModule.provideOkHttpClient(loggingInterceptor, requestInterceptor).newBuilder().addInterceptor { chain ->
+    val loggingInterceptor = NetworkModule.provideHttpLoggingInterceptor()
+    val requestInterceptor = NetworkModule.provideRequestInterceptor(preferencesHelper, configMemoryHolder)
+    val moshi = NetworkModule.provideMoshi()
+    val okHttpClient = NetworkModule.provideOkHttpClient(loggingInterceptor, requestInterceptor).newBuilder().addInterceptor { chain ->
         var request = chain.request()
         chain.proceed(request)
     }.readTimeout(1, TimeUnit.SECONDS).build()
-    val retrofit = networkModule.provideRetrofit(okHttpClient, moshi, preferencesHelper)
+    val retrofit = NetworkModule.provideRetrofit(okHttpClient, moshi, preferencesHelper)
     val constructorApi = retrofit.create(ConstructorApi::class.java)
     return DataManager(constructorApi, moshi);
 }

--- a/library/src/test/java/io/constructor/util/TestDataLoader.kt
+++ b/library/src/test/java/io/constructor/util/TestDataLoader.kt
@@ -1,6 +1,5 @@
 package io.constructor.util
 
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.squareup.moshi.Moshi
 import io.constructor.data.model.autocomplete.AutocompleteResponse
 import io.constructor.data.model.search.SearchResponse
@@ -19,7 +18,7 @@ object TestDataLoader {
 
     private fun loadResult(fileName: String): AutocompleteResponse? {
         val file = File(TestDataLoader::class.java.classLoader.getResource(fileName).path)
-        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        val moshi = Moshi.Builder().build()
         val jsonAdapter = moshi.adapter(AutocompleteResponse::class.java)
         var response: AutocompleteResponse? = null
         try {
@@ -31,7 +30,7 @@ object TestDataLoader {
     }
 
     private fun convertToSearchResult(stringResponse: String): SearchResponse? {
-        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        val moshi = Moshi.Builder().build()
         val jsonAdapter = moshi.adapter(SearchResponse::class.java)
         var result: SearchResponse? = null
         try {


### PR DESCRIPTION
This PR fixes several issues that we were having with using the latest version of the library:

1. The library would not initialize because the Moshi used for `VariationsMap` was not configured to handle Kotlin classes.
2. Using Constructor.io data models required us to use the runtime library `moshi-kotlin`, while our main project only uses the compile-time library `moshi-kotlin-codegen`.
3. Having to depend on certain parts  of the ConstructorIO Dagger dependency graph for custom endpoints caused duplicate dependency mappings for resources commonly used in most Android applications.

To fix this, I've made a few changes to the library:

1. All JSON models are now generated at compile time, and there is no need to use `moshi-kotlin` in this library or in user projects. This also fixes the `VariationsMap` initialization problem in `ConstructorIo`.
2. All Dagger dependencies that are not owned by ConstructorIO or otherwise qualified are now provided using the `@ConstructorSdk` annotation. Note that this is a public annotation so that some of those dependencies could still be used by user projects for customized endpoints.
3. A new test dependency for AssertJ has been added, and used to update various tests that started failing after fixing the ConstructorIo initialization issue. After properly configuring Moshi for Kotlin, the order of the properties converted into JSON had changed, resulting in some hard-coded encoded URL strings to no longer be valid. The tests have been updated to be more flexible, human readable, and more correct. I would recommend updating other tests in a similar fashion, as `assert()` has poor support for expressing why the assertion failed in test reports.