### PR TITLE
[CSL-1566] Support variation_ids in tracking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,4 +271,8 @@ ConstructorIo.trackConversion("Fashionable Toothpicks", "1234567-AB", 12.99, "to
 
 // Track when items are purchased (customerIds, revenue, orderId)
 ConstructorIo.trackPurchase(arrayOf("1234567-AB", "1234567-AB"), 25.98, "ORD-1312343")
+
+// v2.18.4+ only
+// Track when items are purchased (PurchaseItems(itemId, variationId?, quantity?), revenue, orderId)
+ConstructorIo.trackPurchase(arrayOf(PurchaseItem("TIT-REP-1997", "RED", 2), PurchaseItem("QE2-REP-1969")), 25.98, "ORD-1312343")
 ```

--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ ConstructorIo.trackSearchResultsLoaded("tooth", 789, arrayOf("1234567-AB", "1234
 
 // Track when a search result is clicked (itemName, customerId, searchTerm, sectionName, resultId)
 ConstructorIo.trackSearchResultClick("Fashionable Toothpicks", "1234567-AB", "tooth", "Products", "179b8a0e-3799-4a31-be87-127b06871de2")
+
+// v2.18.4+ only
+// Track when a search result is clicked (itemName, customerId, variationId, searchTerm, sectionName, resultId)
+ConstructorIo.trackSearchResultClick("Fashionable Toothpicks", "1234567-AB", "RED", "tooth", "Products", "179b8a0e-3799-4a31-be87-127b06871de2")
 ```
 
 ### Browse Events
@@ -251,6 +255,10 @@ ConstructorIo.trackBrowseResultsLoaded("Category", "Snacks", 674)
 
 // Track when a browse result is clicked (filterName, filterValue, customerId, resultPositionOnPage, sectionName, resultId)
 ConstructorIo.trackBrowseResultClick("Category", "Snacks", "7654321-BA", "4", "Products", "179b8a0e-3799-4a31-be87-127b06871de2")
+
+// v2.18.4+ only
+// Track when a browse result is clicked (filterName, filterValue, customerId, variationId, resultPositionOnPage, sectionName, resultId)
+ConstructorIo.trackBrowseResultClick("Category", "Snacks", "7654321-BA", "RED", "4", "Products", "179b8a0e-3799-4a31-be87-127b06871de2")
 ```
 
 ### Recommendation Events
@@ -268,6 +276,10 @@ ConstructorIo.trackRecommendationResultsView("Best_Sellers", 4, 1, 4, "179b8a0e-
 ```kotlin
 // Track when an item converts (a.k.a. is added to cart) regardless of the user journey that led to adding to cart (itemName, customerId, revenue, searchTerm, section, conversionType)
 ConstructorIo.trackConversion("Fashionable Toothpicks", "1234567-AB", 12.99, "tooth", "Products", "add_to_cart")
+
+// v2.18.4+ only
+// Track when an item converts (a.k.a. is added to cart) regardless of the user journey that led to adding to cart (itemName, customerId, variationId, revenue, searchTerm, section, conversionType)
+ConstructorIo.trackConversion("Fashionable Toothpicks", "1234567-AB", "RED", 12.99, "tooth", "Products", "add_to_cart")
 
 // Track when items are purchased (customerIds, revenue, orderId)
 ConstructorIo.trackPurchase(arrayOf("1234567-AB", "1234567-AB"), 25.98, "ORD-1312343")

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -612,17 +612,37 @@ object ConstructorIo {
      * @param resultID the result ID of the search response that the click came from
     */
     fun trackSearchResultClick(itemName: String, customerId: String, searchTerm: String = Constants.QueryConstants.TERM_UNKNOWN, sectionName: String? = null, resultID: String? = null) {
-        var completable = trackSearchResultClickInternal(itemName, customerId, searchTerm, sectionName, resultID)
+        var completable = trackSearchResultClickInternal(itemName, customerId, null, searchTerm, sectionName, resultID)
         disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
             t -> e("Search Result Click error: ${t.message}")
         }))
     }
-    internal fun trackSearchResultClickInternal(itemName: String, customerId: String, searchTerm: String = Constants.QueryConstants.TERM_UNKNOWN, sectionName: String? = null, resultID: String? = null): Completable {
+
+    /**
+     * Tracks search result click events
+     * ##Example
+     * ```
+     * ConstructorIo.trackSearchResultClick("Fashionable Toothpicks", "1234567-AB", "tooth", "Products", "179b8a0e-3799-4a31-be87-127b06871de2")
+     * ```
+     * @param itemName the name of the clicked item i.e. "Kabocha Pumpkin"
+     * @param customerId the identifier of the clicked item i.e "PUMP-KAB-0002"
+     * @param searchTerm the term that results are displayed for, i.e. "Pumpkin"
+     * @param sectionName the section that the results came from, i.e. "Products"
+     * @param resultID the result ID of the search response that the click came from
+     */
+    fun trackSearchResultClick(itemName: String, customerId: String, variationId: String?, searchTerm: String = Constants.QueryConstants.TERM_UNKNOWN, sectionName: String? = null, resultID: String? = null) {
+        var completable = trackSearchResultClickInternal(itemName, customerId, variationId, searchTerm, sectionName, resultID)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Search Result Click error: ${t.message}")
+        }))
+    }
+
+    internal fun trackSearchResultClickInternal(itemName: String, customerId: String, variationId: String?, searchTerm: String = Constants.QueryConstants.TERM_UNKNOWN, sectionName: String? = null, resultID: String? = null): Completable {
         preferenceHelper.getSessionId(sessionIncrementHandler)
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         resultID?.let { encodedParams.add(Constants.QueryConstants.RESULT_ID.urlEncode() to it.urlEncode()) }
         val sName = sectionName ?: preferenceHelper.defaultItemSection
-        return dataManager.trackSearchResultClick(itemName, customerId, searchTerm, arrayOf(
+        return dataManager.trackSearchResultClick(itemName, customerId, variationId, searchTerm, arrayOf(
                 Constants.QueryConstants.SECTION to sName
         ), encodedParams.toTypedArray())
 
@@ -763,12 +783,34 @@ object ConstructorIo {
      * @param resultID the result ID of the browse response that the selection came from
      */
     fun trackBrowseResultClick(filterName: String, filterValue: String, customerId: String, resultPositionOnPage: Int, sectionName: String? = null, resultID: String? = null) {
-        var completable = trackBrowseResultClickInternal(filterName, filterValue, customerId, resultPositionOnPage, sectionName, resultID)
+        var completable = trackBrowseResultClickInternal(filterName, filterValue, customerId, null, resultPositionOnPage, sectionName, resultID)
         disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
             t -> e("Browse Result Click error: ${t.message}")
         }))
     }
-    internal fun trackBrowseResultClickInternal(filterName: String, filterValue: String, customerId: String, resultPositionOnPage: Int, sectionName: String? = null, resultID: String? = null): Completable {
+
+    /**
+     * Tracks browse result click events
+     * ##Example
+     * ```
+     * ConstructorIo.trackBrowseResultClick("Category", "Snacks", "7654321-BA", "4", "Products", "179b8a0e-3799-4a31-be87-127b06871de2")
+     * ```
+     * @param filterName the name of the primary filter, i.e. "Aisle"
+     * @param filterValue the value of the primary filter, i.e. "Produce"
+     * @param customerId the item identifier of the clicked item i.e "PUMP-KAB-0002"
+     * @param variationId the variation identifier of the clicked item variation i.e "PUMP-KAB-0002-RED"
+     * @param resultPositionOnPage the position of the clicked item on the page i.e. 4
+     * @param sectionName the section that the results came from, i.e. "Products"
+     * @param resultID the result ID of the browse response that the selection came from
+     */
+    fun trackBrowseResultClick(filterName: String, filterValue: String, customerId: String, variationId: String, resultPositionOnPage: Int, sectionName: String? = null, resultID: String? = null) {
+        var completable = trackBrowseResultClickInternal(filterName, filterValue, customerId, variationId, resultPositionOnPage, sectionName, resultID)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Browse Result Click error: ${t.message}")
+        }))
+    }
+
+    internal fun trackBrowseResultClickInternal(filterName: String, filterValue: String, customerId: String, variationId: String? = null, resultPositionOnPage: Int, sectionName: String? = null, resultID: String? = null): Completable {
         preferenceHelper.getSessionId(sessionIncrementHandler)
         val encodedParams: ArrayList<Pair<String, String>> = arrayListOf()
         resultID?.let { encodedParams.add(Constants.QueryConstants.RESULT_ID.urlEncode() to it.urlEncode()) }
@@ -777,6 +819,7 @@ object ConstructorIo {
                 filterName,
                 filterValue,
                 customerId,
+                variationId,
                 resultPositionOnPage,
                 BuildConfig.CLIENT_VERSION,
                 preferenceHelper.id,

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -752,7 +752,7 @@ object ConstructorIo {
     internal fun trackPurchaseInternal(items: Array<PurchaseItem>, revenue: Double?, orderID: String, sectionName: String? = null): Completable {
         var itemsCopy: MutableList<PurchaseItem> = ArrayList()
         for (item in items) {
-            repeat(item.quantity ?: 1) { itemsCopy.add(item) }
+            repeat(item.quantity) { itemsCopy.add(item) }
         }
         preferenceHelper.getSessionId(sessionIncrementHandler)
         val sectionNameParam = sectionName ?: preferenceHelper.defaultItemSection

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -750,11 +750,15 @@ object ConstructorIo {
     }
 
     internal fun trackPurchaseInternal(items: Array<PurchaseItem>, revenue: Double?, orderID: String, sectionName: String? = null): Completable {
+        var itemsCopy: MutableList<PurchaseItem> = ArrayList()
+        for (item in items) {
+            repeat(item.quantity ?: 1) { itemsCopy.add(item) }
+        }
         preferenceHelper.getSessionId(sessionIncrementHandler)
         val sectionNameParam = sectionName ?: preferenceHelper.defaultItemSection
         val params = mutableListOf(Constants.QueryConstants.SECTION to sectionNameParam)
         val purchaseRequestBody = PurchaseRequestBody(
-                items.toList(),
+                itemsCopy,
                 orderID,
                 revenue,
                 BuildConfig.CLIENT_VERSION,

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -626,6 +626,7 @@ object ConstructorIo {
      * ```
      * @param itemName the name of the clicked item i.e. "Kabocha Pumpkin"
      * @param customerId the identifier of the clicked item i.e "PUMP-KAB-0002"
+     * @param variationId the variation identifier of the clicked item variation i.e "PUMP-KAB-0002-RED"
      * @param searchTerm the term that results are displayed for, i.e. "Pumpkin"
      * @param sectionName the section that the results came from, i.e. "Products"
      * @param resultID the result ID of the search response that the click came from

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -90,8 +90,8 @@ constructor(private val constructorApi: ConstructorApi, @ConstructorSdk private 
         return constructorApi.trackConversion(conversionRequestBody, params.toMap())
     }
 
-    fun trackSearchResultClick(itemName: String, customerId: String, term: String, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
-        return constructorApi.trackSearchResultClick(term, itemName, customerId, params.toMap(), encodedParams.toMap())
+    fun trackSearchResultClick(itemName: String, customerId: String, variationId: String?, term: String, params: Array<Pair<String, String>> = arrayOf(), encodedParams: Array<Pair<String,  String>> = arrayOf()): Completable {
+        return constructorApi.trackSearchResultClick(term, itemName, customerId, variationId, params.toMap(), encodedParams.toMap())
     }
 
     fun trackSearchResultsLoaded(term: String, resultCount: Int, customerIds: Array<String>? = null, params: Array<Pair<String, String>>): Completable {

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
@@ -13,6 +13,7 @@ data class BrowseResultClickRequestBody(
         @Json(name = "filter_name") val filterName: String,
         @Json(name = "filter_value") val filterValue: String,
         @Json(name = "item_id") val item_id: String,
+        @Json(name= "variation_id") val variation_id: String?,
         @Json(name = "result_position_on_page") val resultPositionOnPage: Int,
         @Json(name = "c") val c: String,
         @Json(name = "i") val i: String,

--- a/library/src/main/java/io/constructor/data/model/conversion/ConversionRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/conversion/ConversionRequestBody.kt
@@ -12,6 +12,7 @@ import java.io.Serializable
 data class ConversionRequestBody(
         @Json(name = "search_term") val searchTerm: String,
         @Json(name = "item_id") val itemID: String,
+        @Json(name = "variation_id") val variationId: String?,
         @Json(name = "item_name") val itemName: String,
         @Json(name = "revenue") val revenue: String,
         @Json(name = "conversion_type") val conversionType: String?,

--- a/library/src/main/java/io/constructor/data/model/purchase/PurchaseItem.kt
+++ b/library/src/main/java/io/constructor/data/model/purchase/PurchaseItem.kt
@@ -11,5 +11,6 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class PurchaseItem(
         @Json(name = "item_id") val itemId: String?,
-        @Json(name = "variation_id") val variationId: String? = null
+        @Json(name = "variation_id") val variationId: String? = null,
+        @Transient val quantity: Int? = 1
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/purchase/PurchaseItem.kt
+++ b/library/src/main/java/io/constructor/data/model/purchase/PurchaseItem.kt
@@ -12,5 +12,5 @@ import java.io.Serializable
 data class PurchaseItem(
         @Json(name = "item_id") val itemId: String?,
         @Json(name = "variation_id") val variationId: String? = null,
-        @Transient val quantity: Int? = 1
+        @Transient val quantity: Int = 1
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -41,6 +41,7 @@ interface ConstructorApi {
     fun trackSearchResultClick(@Path("term") term: String,
                                @Query("name") itemName: String,
                                @Query("customer_id") customerId: String,
+                               @Query("variation_id") variationId: String?,
                                @QueryMap params: Map<String, String>,
                                @QueryMap(encoded = true) encodedData: Map<String, String>): Completable
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -8,6 +8,7 @@ import io.constructor.data.builder.SearchRequest
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
 import io.constructor.data.model.common.VariationsMap
+import io.constructor.data.model.purchase.PurchaseItem
 import io.constructor.test.createTestDataManager
 import io.constructor.util.RxSchedulersOverrideRule
 import io.mockk.every
@@ -163,6 +164,7 @@ class ConstructorIoIntegrationTest {
         val observer = constructorIo.trackConversionInternal(
             "Boneless Pork Shoulder Roast",
             "prrst_shldr_bls",
+            null,
             1.99
         ).test()
         observer.assertComplete()
@@ -172,7 +174,7 @@ class ConstructorIoIntegrationTest {
     @Test
     fun trackPurchaseAgainstRealResponse() {
         val observer = constructorIo.trackPurchaseInternal(
-            arrayOf("prrst_shldr_bls", "prrst_crwn"),
+            arrayOf(PurchaseItem("prrst_shldr_bls"), PurchaseItem("prrst_crwn")),
             9.98,
             "45273",
             "Products"

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -151,6 +151,7 @@ class ConstructorIoIntegrationTest {
         val observer = constructorIo.trackSearchResultClickInternal(
             "Boneless Pork Shoulder Roast",
             "prrst_shldr_bls",
+            null,
             "pork"
         ).test()
         observer.assertComplete()
@@ -190,7 +191,7 @@ class ConstructorIoIntegrationTest {
     @Test
     fun trackBrowseResultClickAgainstRealResponse() {
         val observer =
-            constructorIo.trackBrowseResultClickInternal("group_ids", "544", "prrst_shldr_bls", 5)
+            constructorIo.trackBrowseResultClickInternal("group_ids", "544", "prrst_shldr_bls",null,5)
                 .test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -301,7 +301,7 @@ class ConstructorIoTrackingTest {
     fun trackSearchResultClick() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", "titanic").test()
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997",null, "titanic").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
@@ -309,10 +309,21 @@ class ConstructorIoTrackingTest {
     }
 
     @Test
+    fun trackSearchResultClickWithVariationId() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997","RED", "titanic").test()
+        observer.assertComplete()
+        val request = mockServer.takeRequest()
+        val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&variation_id=RED&section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun trackSearchResultClickWithSectionAndResultID() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", "titanic", "Products","3467632").test()
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", null,"titanic", "Products","3467632").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&section=Products&result_id=3467632&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
@@ -323,7 +334,7 @@ class ConstructorIoTrackingTest {
     fun trackSearchResultClick500() {
         val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", "titanic").test()
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997",null, "titanic").test()
         observer.assertError { true }
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
@@ -335,7 +346,7 @@ class ConstructorIoTrackingTest {
         val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
         mockResponse.throttleBody(0, 5, TimeUnit.SECONDS)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", "titanic").test()
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997",null, "titanic").test()
         observer.assertError(SocketTimeoutException::class.java)
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
@@ -512,7 +523,7 @@ class ConstructorIoTrackingTest {
     fun trackBrowseResultClick() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
+        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", null,4).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val requestBody = getRequestBody(request)
@@ -521,6 +532,25 @@ class ConstructorIoTrackingTest {
         assertEquals("Movies", requestBody["filter_value"])
         assertEquals("TIT-REP-1997", requestBody["item_id"])
         assertEquals("4", requestBody["result_position_on_page"])
+        assertEquals(null, requestBody["variation_id"])
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
+    fun trackBrowseResultClickWithVariationId() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", "RED",4).test()
+        observer.assertComplete()
+        val request = mockServer.takeRequest()
+        val requestBody = getRequestBody(request)
+        val path = "/v2/behavioral_action/browse_result_click?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        assertEquals("group_id", requestBody["filter_name"])
+        assertEquals("Movies", requestBody["filter_value"])
+        assertEquals("TIT-REP-1997", requestBody["item_id"])
+        assertEquals("4", requestBody["result_position_on_page"])
+        assertEquals("RED", requestBody["variation_id"])
         assertEquals("POST", request.method)
         assert(request.path!!.startsWith(path))
     }
@@ -529,7 +559,7 @@ class ConstructorIoTrackingTest {
     fun trackBrowseResultClickWithSectionAndResultID() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4, "Products", "3467632").test()
+        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", null, 4, "Products", "3467632").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val requestBody = getRequestBody(request)
@@ -546,7 +576,7 @@ class ConstructorIoTrackingTest {
     fun trackBrowseResultClick500() {
         val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
+        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", null,4).test()
         observer.assertError { true }
         val request = mockServer.takeRequest()
         val requestBody = getRequestBody(request)
@@ -564,7 +594,7 @@ class ConstructorIoTrackingTest {
         val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
         mockResponse.throttleBody(0, 5, TimeUnit.SECONDS)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", 4).test()
+        val observer = ConstructorIo.trackBrowseResultClickInternal("group_id", "Movies","TIT-REP-1997", null, 4).test()
         observer.assertError(SocketTimeoutException::class.java)
         val request = mockServer.takeRequest(10, TimeUnit.SECONDS)
         assertEquals(null, request)

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -453,6 +453,22 @@ class ConstructorIoTrackingTest {
     }
 
     @Test
+    fun trackPurchaseWithQuantity() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+        val observer = ConstructorIo.trackPurchaseInternal(arrayOf(PurchaseItem("TIT-REP-1997", null, 2), PurchaseItem("QE2-REP-1969")), 12.99, "ORD-1312343").test()
+        observer.assertComplete()
+        val request = mockServer.takeRequest()
+        val requestBody = getRequestBody(request)
+        val path = "/v2/behavioral_action/purchase?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        assertEquals("[{item_id:TIT-REP-1997},{item_id:TIT-REP-1997},{item_id:QE2-REP-1969}]", requestBody["items"])
+        assertEquals("ORD-1312343", requestBody["order_id"])
+        assertEquals("12.99", requestBody["revenue"])
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun trackPurchaseWithVariationId() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)

--- a/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
@@ -126,7 +126,7 @@ class ConstructorioSegmentsTest {
     fun trackSearchResultClick() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", "titanic").test()
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", null,"titanic").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&section=Products&key=aluminium-key&i=koopa-the-guid&ui=player-two&s=14&us=mobile&us=COUNTRY_US&c=cioand-2.18.1&_dt=";

--- a/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
@@ -3,6 +3,7 @@ package io.constructor.core
 import android.content.Context
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
+import io.constructor.data.model.purchase.PurchaseItem
 import io.constructor.test.createTestDataManager
 import io.constructor.util.RxSchedulersOverrideRule
 import io.constructor.util.TestDataLoader
@@ -137,7 +138,7 @@ class ConstructorioSegmentsTest {
     fun trackConversion() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackConversionInternal("titanic replica", "TIT-REP-1997", 89.00).test()
+        val observer = ConstructorIo.trackConversionInternal("titanic replica", "TIT-REP-1997", null, 89.00).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/conversion?key=aluminium-key&i=koopa-the-guid&ui=player-two&s=14&us=mobile&us=COUNTRY_US&c=cioand-2.18.1&_dt=";
@@ -148,7 +149,7 @@ class ConstructorioSegmentsTest {
     fun trackPurchase() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackPurchaseInternal(arrayOf("TIT-REP-1997", "QE2-REP-1969"), 12.99, "ORD-1312343").test()
+        val observer = ConstructorIo.trackPurchaseInternal(arrayOf(PurchaseItem("TIT-REP-1997"), PurchaseItem("QE2-REP-1969")), 12.99, "ORD-1312343").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/purchase?section=Products&key=aluminium-key&i=koopa-the-guid&ui=player-two&s=14&us=mobile&us=COUNTRY_US&c=cioand-2.18.1&_dt=";

--- a/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
@@ -3,6 +3,7 @@ package io.constructor.core
 import android.content.Context
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.memory.ConfigMemoryHolder
+import io.constructor.data.model.purchase.PurchaseItem
 import io.constructor.test.createTestDataManager
 import io.constructor.util.RxSchedulersOverrideRule
 import io.constructor.util.TestDataLoader
@@ -138,7 +139,7 @@ class ConstructorioTestCellTest {
     fun trackConversion() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackConversionInternal("titanic replica", "TIT-REP-1997", 89.00).test()
+        val observer = ConstructorIo.trackConversionInternal("titanic replica", "TIT-REP-1997", null, 89.00).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/conversion?key=aluminium-key&i=koopa-the-guid&ui=player-two&s=14&ef-cellone=vanilla&ef-celltwo=whipped-cream&c=cioand-2.18.1&_dt=";
@@ -149,7 +150,7 @@ class ConstructorioTestCellTest {
     fun trackPurchase() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackPurchaseInternal(arrayOf("TIT-REP-1997", "QE2-REP-1969"), 12.99, "ORD-1312343").test()
+        val observer = ConstructorIo.trackPurchaseInternal(arrayOf(PurchaseItem("TIT-REP-1997"), PurchaseItem("QE2-REP-1969")), 12.99, "ORD-1312343").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/v2/behavioral_action/purchase?section=Products&key=aluminium-key&i=koopa-the-guid&ui=player-two&s=14&ef-cellone=vanilla&ef-celltwo=whipped-cream&c=cioand-2.18.1&_dt=";

--- a/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
@@ -127,7 +127,7 @@ class ConstructorioTestCellTest {
     fun trackSearchResultClick() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", "titanic").test()
+        val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997", null, "titanic").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&section=Products&key=aluminium-key&i=koopa-the-guid&ui=player-two&s=14&ef-cellone=vanilla&ef-celltwo=whipped-cream&c=cioand-2.18.1&_dt=";


### PR DESCRIPTION
Added variation_ids to browse result clicks and search result clicks.