### PR TITLE
[CSL 1774] Update tests to have accurate assertions

### DIFF
--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ConstructorIoIntegrationTest {
@@ -57,11 +58,14 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getAutocompleteResultsAgainstRealResponse() {
         val observer = constructorIo.getAutocompleteResults("pork").test()
-        observer.assertComplete().assertValue {
-            it.get()?.sections!!.isNotEmpty()
-            it.get()?.resultId!!.isNotEmpty()
-            it.get()?.sections!!["Products"]?.first()?.isSlotted == true
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val autocompleteResponse = observer.values()[0].get()
+        assertTrue(autocompleteResponse?.sections!!.isNotEmpty())
+        assertTrue(autocompleteResponse?.resultId!!.isNotEmpty())
+        assertEquals(autocompleteResponse?.sections!!["Products"]?.first()?.isSlotted, true)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -112,15 +116,19 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getSearchResultsAgainstRealResponse() {
         val observer = constructorIo.getSearchResults("pork").test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.results?.first()?.isSlotted == true
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+        assertEquals(searchResponse?.response?.results?.first()?.isSlotted, true)
+
+        Thread.sleep(timeBetweenTests)
     }
 
     @Test
@@ -163,15 +171,18 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getBrowseResultsAgainstRealResponse() {
         val observer = constructorIo.getBrowseResults("group_id", "744").test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.results?.first()?.isSlotted == true
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.resultCount!! > 0)
+        assertEquals(browseResponse?.response?.results?.first()?.isSlotted, true)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -284,13 +295,16 @@ class ConstructorIoIntegrationTest {
     fun getRecommendationResultsAgainstRealResponse() {
         val facet = hashMapOf("Claims" to listOf("Organic"))
         val observer = constructorIo.getRecommendationResults("pdp3", facet.map { it.key to it.value }).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.pod !== null
-            it.get()?.response?.results !== null
-            it.get()?.response?.resultCount!! >= 0
-            it.get()?.response?.results?.first()?.isSlotted == false
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertTrue(recommendationResponse?.resultId !== null)
+        assertTrue(recommendationResponse?.response?.pod !== null)
+        assertTrue(recommendationResponse?.response?.results !== null)
+        assertTrue(recommendationResponse?.response?.resultCount!! >= 0)
+        assertEquals(recommendationResponse?.response?.results?.first()?.isSlotted, false)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -329,14 +343,15 @@ class ConstructorIoIntegrationTest {
     fun getAutocompleteResultsWithHiddenFieldsAgainstRealResponse() {
         val hiddenFields = listOf("hiddenField1", "hiddenField2")
         val observer = constructorIo.getAutocompleteResults("pork", null, null, hiddenFields).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.sections!!.isNotEmpty()
-            it.get()?.sections?.get("Products")
-                ?.first()?.data?.metadata?.get("hiddenField1") !== null
-            it.get()?.sections?.get("Products")
-                ?.first()?.data?.metadata?.get("hiddenField2") !== null
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val autocompleteResponse = observer.values()[0].get()
+        assertTrue(autocompleteResponse?.resultId !== null)
+        assertTrue(autocompleteResponse?.sections!!.isNotEmpty())
+        assertTrue(autocompleteResponse?.sections?.get("Products")?.first()?.data?.metadata?.get("hiddenField1") !== null)
+        assertTrue(autocompleteResponse?.sections?.get("Products")?.first()?.data?.metadata?.get("hiddenField2") !== null)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -344,22 +359,18 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultsWithHiddenFieldsAgainstRealResponse() {
         val hiddenFields = listOf("hiddenField1", "hiddenField2")
         val observer = constructorIo.getSearchResults(
-            "pork",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            hiddenFields
+            term =  "pork",
+            hiddenFields = hiddenFields
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.results?.first()?.data?.metadata?.get("hiddenField1") !== null
-            it.get()?.response?.results?.first()?.data?.metadata?.get("hiddenField2") !== null
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.results?.first()?.data?.metadata?.get("hiddenField1") !== null)
+        assertTrue(searchResponse?.response?.results?.first()?.data?.metadata?.get("hiddenField2") !== null)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -367,24 +378,18 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultsWithHiddenFacetsAgainstRealResponse() {
         val hiddenFacets = listOf("Brand")
         val observer = constructorIo.getSearchResults(
-            "pork",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            hiddenFacets
+            term = "pork",
+            hiddenFacets = hiddenFacets
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.facets!!.isNotEmpty()
-            val brandFacet =
-                it.get()?.response?.facets?.find { facet -> facet.name.contains("Brand") }
-            brandFacet !== null
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        val brandFacet = searchResponse?.response?.facets?.find { facet -> facet.name.contains("Brand") }
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(brandFacet !== null)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -395,11 +400,14 @@ class ConstructorIoIntegrationTest {
             groupsSortBy = "value",
             groupsSortOrder = "ascending"
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.groups?.get(0)?.displayName == "Dairy"
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertEquals(searchResponse?.response?.groups?.get(0)?.displayName, "Dairy")
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -410,11 +418,14 @@ class ConstructorIoIntegrationTest {
             groupsSortBy = "value",
             groupsSortOrder = "descending"
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.groups?.get(0)?.displayName == "Meat & Poultry"
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertEquals(searchResponse?.response?.groups?.get(0)?.displayName, "Meat & Poultry")
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -422,23 +433,19 @@ class ConstructorIoIntegrationTest {
     fun getBrowseResultsWithHiddenFieldsAgainstRealResponse() {
         val hiddenFields = listOf("hiddenField1", "hiddenField2")
         val observer = constructorIo.getBrowseResults(
-            "group_id",
-            "431",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            hiddenFields
+            filterName = "group_id",
+            filterValue = "431",
+            hiddenFields = hiddenFields
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.results?.first()?.data?.metadata?.get("hiddenField1") !== null
-            it.get()?.response?.results?.first()?.data?.metadata?.get("hiddenField2") !== null
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.results?.first()?.data?.metadata?.get("hiddenField1") !== null)
+        assertTrue(browseResponse?.response?.results?.first()?.data?.metadata?.get("hiddenField2") !== null)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -446,47 +453,48 @@ class ConstructorIoIntegrationTest {
     fun getBrowseResultsWithHiddenFacetsAgainstRealResponse() {
         val hiddenFacets = listOf("Brand")
         val observer = constructorIo.getBrowseResults(
-            "group_id",
-            "431",
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            hiddenFacets
+            filterName = "group_id",
+            filterValue = "431",
+            hiddenFacets = hiddenFacets,
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.facets!!.isNotEmpty()
-            val brandFacet =
-                it.get()?.response?.facets?.find { facet -> facet.name.contains("Brand") }
-            brandFacet !== null
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        val brandFacet = browseResponse?.response?.facets?.find { facet -> facet.name.contains("Brand")}
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(brandFacet !== null)
+
         Thread.sleep(timeBetweenTests)
     }
 
     @Test
     fun getBrowseResultsWithCollectionAgainstRealResponse() {
         val observer = constructorIo.getBrowseResults("collection_id", "test-collection").test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.collection?.id == "test-collection"
-            it.get()?.response?.collection?.displayName == "test collection"
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertEquals(browseResponse?.response?.collection?.id, "test-collection")
+        assertEquals(browseResponse?.response?.collection?.displayName, "test collection")
+
+        Thread.sleep(timeBetweenTests)
     }
 
     @Test
     fun getAutocompleteResultsAgainstRealResponseUsingRequestBuilder() {
         val request = AutocompleteRequest.Builder("pork").build()
         val observer = constructorIo.getAutocompleteResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.sections!!.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val autocompleteResponse = observer.values()[0].get()
+        assertTrue(autocompleteResponse?.resultId !== null)
+        assertTrue(autocompleteResponse?.sections!!.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -502,13 +510,15 @@ class ConstructorIoIntegrationTest {
         val request =
             AutocompleteRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getAutocompleteResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.sections!!.isNotEmpty()
-            val returnedVariationsMap =
-                it.get()?.sections!!["Products"]?.get(0)?.variationsMap as List<*>
-            returnedVariationsMap.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val autocompleteResponse = observer.values()[0].get()
+        val returnedVariationsMap = autocompleteResponse?.sections!!["Products"]?.get(0)?.variationsMap as List<*>
+        assertTrue(autocompleteResponse?.resultId !== null)
+        assertTrue(autocompleteResponse?.sections!!.isNotEmpty())
+        assertTrue(returnedVariationsMap.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -524,13 +534,15 @@ class ConstructorIoIntegrationTest {
         val request =
             AutocompleteRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getAutocompleteResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.sections!!.isNotEmpty()
-            val returnedVariationsMap =
-                it.get()?.sections!!["Products"]?.get(0)?.variationsMap as Map<*, *>
-            returnedVariationsMap.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val autocompleteResponse = observer.values()[0].get()
+        val returnedVariationsMap = autocompleteResponse?.sections!!["Products"]?.get(0)?.variationsMap as Map<*, *>
+        assertTrue(autocompleteResponse?.resultId !== null)
+        assertTrue(autocompleteResponse?.sections!!.isNotEmpty())
+        assertTrue(returnedVariationsMap.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -538,14 +550,17 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultAgainstRealResponseUsingRequestBuilder() {
         val request = SearchRequest.Builder("pork").build()
         val observer = constructorIo.getSearchResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -560,16 +575,19 @@ class ConstructorIoIntegrationTest {
         )
         val request = SearchRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getSearchResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            val returnedVariationsMap = it.get()?.response?.results!![0].variationsMap as? List<*>
-            returnedVariationsMap!!.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        val returnedVariationsMap = searchResponse?.response?.results!![0].variationsMap as? List<*>
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+        assertTrue(returnedVariationsMap!!.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -584,16 +602,19 @@ class ConstructorIoIntegrationTest {
         )
         val request = SearchRequest.Builder("angus beef").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getSearchResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            val returnedVariationsMap = it.get()?.response?.results!![0].variationsMap as? Map<*, *>
-            returnedVariationsMap!!.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        val returnedVariationsMap = searchResponse?.response?.results!![0].variationsMap as? Map<*, *>
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+        assertTrue(returnedVariationsMap!!.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -601,16 +622,19 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultAgainstRealResponseWithResultSources() {
         val request = SearchRequest.Builder("angus beef").build()
         val observer = constructorIo.getSearchResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.resultSources!!.embeddingsMatch!!.count!! >= 0
-            it.get()?.response?.resultSources!!.tokenMatch!!.count!! >= 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+        assertTrue(searchResponse?.response?.resultSources!!.embeddingsMatch!!.count!! >= 0)
+        assertTrue(searchResponse?.response?.resultSources!!.tokenMatch!!.count!! >= 0)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -618,14 +642,17 @@ class ConstructorIoIntegrationTest {
     fun getBrowseResultAgainstRealResponseUsingRequestBuilder() {
         val request = BrowseRequest.Builder("group_id", "431").build()
         val observer = constructorIo.getBrowseResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.resultCount!! > 0)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -641,16 +668,19 @@ class ConstructorIoIntegrationTest {
         val request =
             BrowseRequest.Builder("group_id", "544").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getBrowseResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            val returnedVariationsMap = it.get()?.response?.results!![0].variationsMap as? List<*>
-            returnedVariationsMap!!.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        val returnedVariationsMap = browseResponse?.response?.results!![0].variationsMap as? List<*>
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.resultCount!! > 0)
+        assertTrue(returnedVariationsMap!!.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -666,16 +696,19 @@ class ConstructorIoIntegrationTest {
         val request =
             BrowseRequest.Builder("group_id", "431").setVariationsMap(variationsMap).build()
         val observer = constructorIo.getBrowseResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            val returnedVariationsMap = it.get()?.response?.results!![0].variationsMap as? Map<*, *>
-            returnedVariationsMap!!.isNotEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        val returnedVariationsMap = browseResponse?.response?.results!![0].variationsMap as? Map<*, *>
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.resultCount!! > 0)
+        assertTrue(returnedVariationsMap!!.isNotEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -683,16 +716,19 @@ class ConstructorIoIntegrationTest {
     fun getBrowseResultAgainstRealResponseWithResultSources() {
         val request = BrowseRequest.Builder("group_id", "431").build()
         val observer = constructorIo.getBrowseResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.filterSortOptions!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.resultSources!!.embeddingsMatch!!.count!! >= 0
-            it.get()?.response?.resultSources!!.tokenMatch!!.count!! >= 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.filterSortOptions!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.resultCount!! > 0)
+        assertTrue(browseResponse?.response?.resultSources!!.embeddingsMatch!!.count!! >= 0)
+        assertTrue(browseResponse?.response?.resultSources!!.tokenMatch!!.count!! >= 0)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -700,12 +736,15 @@ class ConstructorIoIntegrationTest {
     fun getRecommendationResultsAgainstRealResponseUsingRequestBuilder() {
         val request = RecommendationsRequest.Builder("pdp5").build()
         val observer = constructorIo.getRecommendationResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.pod !== null
-            it.get()?.response?.results !== null
-            it.get()?.response?.resultCount!! >= 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertTrue(recommendationResponse?.resultId !== null)
+        assertTrue(recommendationResponse?.response?.pod !== null)
+        assertTrue(recommendationResponse?.response?.results !== null)
+        assertTrue(recommendationResponse?.response?.resultCount!! >= 0)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -717,12 +756,15 @@ class ConstructorIoIntegrationTest {
             groupsSortBy = "value",
             groupsSortOrder = "ascending",
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.groups?.get(0)?.displayName == "Grocery"
-            it.get()?.response?.groups?.get(0)?.children?.get(0)?.displayName == "Baby"
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertEquals(browseResponse?.response?.groups?.get(0)?.displayName, "Grocery")
+        assertEquals(browseResponse?.response?.groups?.get(0)?.children?.get(0)?.displayName, "Baby")
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -734,12 +776,15 @@ class ConstructorIoIntegrationTest {
             groupsSortBy = "value",
             groupsSortOrder = "descending",
         ).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.groups?.get(0)?.displayName == "Grocery"
-            it.get()?.response?.groups?.get(0)?.children?.get(0)?.displayName == "Pet"
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertEquals(browseResponse?.response?.groups?.get(0)?.displayName, "Grocery")
+        assertEquals(browseResponse?.response?.groups?.get(0)?.children?.get(0)?.displayName, "Pet")
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -747,11 +792,14 @@ class ConstructorIoIntegrationTest {
     fun getAutocompleteResultsWithLabelsAgainstRealResponse() {
         val request = AutocompleteRequest.Builder("pork").build()
         val observer = constructorIo.getAutocompleteResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.sections!!.isNotEmpty()
-            it.get()?.sections?.get("Products")?.first()?.labels!!["is_sponsored"] == true
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val autocompleteResponse = observer.values()[0].get()
+        assertTrue(autocompleteResponse?.resultId !== null)
+        assertTrue(autocompleteResponse?.sections!!.isNotEmpty())
+        assertEquals(autocompleteResponse?.sections?.get("Products")?.first()?.labels!!["is_sponsored"], true)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -759,14 +807,17 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultsWithLabelsAgainstRealResponse() {
         val request = SearchRequest.Builder("pork").build()
         val observer = constructorIo.getSearchResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.results?.first()?.labels!!["is_sponsored"] == true
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+        assertEquals(searchResponse?.response?.results?.first()?.labels!!["is_sponsored"], true)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -774,14 +825,17 @@ class ConstructorIoIntegrationTest {
     fun getBrowseResultsWithLabelsAgainstRealResponse() {
         val request = BrowseRequest.Builder("group_id", "544").build()
         val observer = constructorIo.getBrowseResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.facets!!.isNotEmpty()
-            it.get()?.response?.groups!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.results?.first()?.labels!!["is_sponsored"] == true
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.resultId !== null)
+        assertTrue(browseResponse?.response?.results!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isNotEmpty())
+        assertTrue(browseResponse?.response?.resultCount!! > 0)
+        assertEquals(browseResponse?.response?.results?.first()?.labels!!["is_sponsored"], true)
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -790,12 +844,15 @@ class ConstructorIoIntegrationTest {
         val filters = mapOf("group_id" to listOf("544"))
         val request = RecommendationsRequest.Builder("pdp3").setFilters(filters).build()
         val observer = constructorIo.getRecommendationResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.results?.first()?.labels!!.isNullOrEmpty()
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertTrue(recommendationResponse?.resultId !== null)
+        assertTrue(recommendationResponse?.response?.results!!.isNotEmpty())
+        assertTrue(recommendationResponse?.response?.resultCount!! > 0)
+        assertTrue(recommendationResponse?.response?.results?.first()?.labels!!.isNullOrEmpty())
+
         Thread.sleep(timeBetweenTests)
     }
 
@@ -803,20 +860,24 @@ class ConstructorIoIntegrationTest {
     fun getSearchResultAgainstRealResponseWithRefinedContent() {
         val request = SearchRequest.Builder("superbowl").build()
         val observer = constructorIo.getSearchResults(request).test()
-        observer.assertComplete().assertValue {
-            it.get()?.resultId !== null
-            it.get()?.response?.results!!.isNotEmpty()
-            it.get()?.response?.resultCount!! > 0
-            it.get()?.response?.refinedContent?.first()?.data!!.isNullOrEmpty()
-            it.get()?.response?.refinedContent?.first()?.data?.get("body") === "Content 1 Body"
-            it.get()?.response?.refinedContent?.first()?.data?.get("header") === "Content 1 Header"
-            it.get()?.response?.refinedContent?.first()?.data?.get("assetUrl") === "https://constructor.io/wp-content/uploads/2022/09/groceryshop-2022-r2.png"
-            it.get()?.response?.refinedContent?.first()?.data?.get("altText") === "Content 1 desktop alt text"
-            it.get()?.response?.refinedContent?.first()?.data?.get("ctaLink") === "https://constructor.io/wp-content/uploads/2022/09/groceryshop-2022-r2.png"
-            it.get()?.response?.refinedContent?.first()?.data?.get("ctaText") === "Content 1 CTA Button"
-            it.get()?.response?.refinedContent?.first()?.data?.get("tag-1") === "tag-1-value"
-            it.get()?.response?.refinedContent?.first()?.data?.get("tag-2") === "tag-2-value"
-            it.get()?.response?.refinedContent?.first()?.data?.get("arbitraryDataObject") !== null
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.resultId !== null)
+        assertTrue(searchResponse?.response?.results!!.isNotEmpty())
+        assertTrue(searchResponse?.response?.resultCount!! > 0)
+        assertTrue(searchResponse?.response?.refinedContent?.first()?.data!!.isNullOrEmpty())
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("body"), "Content 1 Body")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("header"), "Content 1 Header")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("assetUrl"), "https://constructor.io/wp-content/uploads/2022/09/groceryshop-2022-r2.png")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("altText"), "Content 1 desktop alt text")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("ctaLink"), "https://constructor.io/wp-content/uploads/2022/09/groceryshop-2022-r2.png")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("ctaText"), "Content 1 CTA Button")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("tag-1"), "tag-1-value")
+        assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("tag-2"), "tag-2-value")
+        assertTrue(searchResponse?.response?.refinedContent?.first()?.data?.get("arbitraryDataObject") !== null)
+
+        Thread.sleep(timeBetweenTests)
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -324,8 +324,8 @@ class ConstructorIoIntegrationTest {
     @Test
     fun trackRecommendationResultClickAgainstRealResponse() {
         val observer = constructorIo.trackRecommendationResultClickInternal(
-            "pdp5",
-            "User Featured",
+            "pdp3",
+            "filtered_items",
             "prrst_shldr_bls"
         ).test()
         observer.assertComplete()
@@ -334,7 +334,7 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun trackRecommendationResultsViewAgainstRealResponse() {
-        val observer = constructorIo.trackRecommendationResultsViewInternal("pdp5", 4).test()
+        val observer = constructorIo.trackRecommendationResultsViewInternal("pdp3", 4).test()
         observer.assertComplete()
         Thread.sleep(timeBetweenTests)
     }
@@ -734,7 +734,10 @@ class ConstructorIoIntegrationTest {
 
     @Test
     fun getRecommendationResultsAgainstRealResponseUsingRequestBuilder() {
-        val request = RecommendationsRequest.Builder("pdp5").build()
+        val filters = mapOf("group_id" to listOf("544"))
+        val request = RecommendationsRequest.Builder("pdp3")
+            .setFilters(filters)
+            .build()
         val observer = constructorIo.getRecommendationResults(request).test()
         observer.assertComplete()
         observer.assertNoErrors()
@@ -867,7 +870,7 @@ class ConstructorIoIntegrationTest {
         assertTrue(searchResponse?.resultId !== null)
         assertTrue(searchResponse?.response?.results!!.isNotEmpty())
         assertTrue(searchResponse?.response?.resultCount!! > 0)
-        assertTrue(searchResponse?.response?.refinedContent?.first()?.data!!.isNullOrEmpty())
+        assertTrue(searchResponse?.response?.refinedContent?.first()?.data!!.isNotEmpty())
         assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("body"), "Content 1 Body")
         assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("header"), "Content 1 Header")
         assertEquals(searchResponse?.response?.refinedContent?.first()?.data?.get("assetUrl"), "https://constructor.io/wp-content/uploads/2022/09/groceryshop-2022-r2.png")

--- a/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoRecommendationsTest.kt
@@ -15,6 +15,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ConstructorIoRecommendationsTest {
 
@@ -59,14 +61,17 @@ class ConstructorIoRecommendationsTest {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("recommendation_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getRecommendationResults("titanic").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.size == 24
-            it.get()!!.response?.results!![0].value == "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz."
-            it.get()!!.response?.results!![0].data.id == "960189161"
-            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png"
-            it.get()!!.response?.results!![0].data.metadata?.get("price") == 1.11
-            it.get()!!.response?.resultCount == 225
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertEquals(recommendationResponse?.response?.results?.size, 24)
+        assertEquals(recommendationResponse?.response?.results!![0].value, "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz.")
+        assertEquals(recommendationResponse?.response?.results!![0].data.id, "960189161")
+        assertEquals(recommendationResponse?.response?.results!![0].data.imageUrl, "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png")
+        assertEquals(recommendationResponse?.response?.results!![0].data.metadata?.get("price"), 1.11)
+        assertEquals(recommendationResponse?.response?.resultCount, 225)
+
         val request = mockServer.takeRequest()
         val path = "/recommendations/v1/pods/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.18.5&_dt="
         assert(request.path!!.startsWith(path))
@@ -104,10 +109,13 @@ class ConstructorIoRecommendationsTest {
         val mockResponse = MockResponse().setResponseCode(200).setBody(TestDataLoader.loadAsString("recommendation_response_empty.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getRecommendationResults("titanic").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.isEmpty()
-            it.get()!!.response?.resultCount == 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertTrue(recommendationResponse?.response?.results!!.isEmpty())
+        assertEquals(recommendationResponse?.response?.resultCount, 0)
+
         val request = mockServer.takeRequest()
         val path = "/recommendations/v1/pods/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.18.5&_dt="
         assert(request.path!!.startsWith(path))
@@ -119,14 +127,17 @@ class ConstructorIoRecommendationsTest {
         mockServer.enqueue(mockResponse)
         val recommendationsRequest = RecommendationsRequest.Builder("titanic").build()
         val observer = constructorIo.getRecommendationResults(recommendationsRequest).test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.size == 24
-            it.get()!!.response?.results!![0].value == "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz."
-            it.get()!!.response?.results!![0].data.id == "960189161"
-            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png"
-            it.get()!!.response?.results!![0].data.metadata?.get("price") == 1.11
-            it.get()!!.response?.resultCount == 225
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertEquals(recommendationResponse?.response?.results?.size, 24)
+        assertEquals(recommendationResponse?.response?.results!![0].value, "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz.")
+        assertEquals(recommendationResponse?.response?.results!![0].data.id, "960189161")
+        assertEquals(recommendationResponse?.response?.results!![0].data.imageUrl, "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png")
+        assertEquals(recommendationResponse?.response?.results!![0].data.metadata?.get("price"), 1.11)
+        assertEquals(recommendationResponse?.response?.resultCount, 225)
+
         val request = mockServer.takeRequest()
         val path = "/recommendations/v1/pods/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.18.5&_dt="
         assert(request.path!!.startsWith(path))
@@ -140,14 +151,17 @@ class ConstructorIoRecommendationsTest {
             .setItemIds(listOf("item_id_1", "item_id_2"))
             .build()
         val observer = constructorIo.getRecommendationResults(recommendationsRequest).test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.size == 24
-            it.get()!!.response?.results!![0].value == "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz."
-            it.get()!!.response?.results!![0].data.id == "960189161"
-            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png"
-            it.get()!!.response?.results!![0].data.metadata?.get("price") == 1.11
-            it.get()!!.response?.resultCount == 225
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val recommendationResponse = observer.values()[0].get()
+        assertEquals(recommendationResponse?.response?.results?.size, 24)
+        assertEquals(recommendationResponse?.response?.results!![0].value, "LaCroix Sparkling Water Pure Cans - 12-12 Fl. Oz.")
+        assertEquals(recommendationResponse?.response?.results!![0].data.id, "960189161")
+        assertEquals(recommendationResponse?.response?.results!![0].data.imageUrl, "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-960189161.png")
+        assertEquals(recommendationResponse?.response?.results!![0].data.metadata?.get("price"), 1.11)
+        assertEquals(recommendationResponse?.response?.resultCount, 225)
+
         val request = mockServer.takeRequest()
         val path = "/recommendations/v1/pods/titanic?item_id=item_id_1&item_id=item_id_2&key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.18.5&_dt="
         assert(request.path!!.startsWith(path))

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -16,9 +16,9 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.net.SocketTimeoutException
+import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
-import java.util.ArrayDeque
 
 
 internal fun getRequestBody(request: RecordedRequest): Map<String, String> {
@@ -316,7 +316,7 @@ class ConstructorIoTrackingTest {
         val observer = ConstructorIo.trackSearchResultClickInternal("titanic replica", "TIT-REP-1997","RED", "titanic").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&variation_id=RED&section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        val path = "/autocomplete/titanic/click_through?name=titanic%20replica&customer_id=TIT-REP-1997&variation_id=RED&section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.5&_dt="
         assert(request.path!!.startsWith(path))
     }
 
@@ -378,7 +378,7 @@ class ConstructorIoTrackingTest {
         val observer = ConstructorIo.trackConversionInternal("titanic replica", "TIT-REP-1997","RED",89.00).test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/v2/behavioral_action/conversion?key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        val path = "/v2/behavioral_action/conversion?key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.5&_dt="
         val requestBody = getRequestBody(request)
         assertEquals("TIT-REP-1997", requestBody["item_id"])
         assertEquals("titanic replica", requestBody["item_name"])
@@ -460,7 +460,7 @@ class ConstructorIoTrackingTest {
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val requestBody = getRequestBody(request)
-        val path = "/v2/behavioral_action/purchase?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        val path = "/v2/behavioral_action/purchase?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.5&_dt="
         assertEquals("[{item_id:TIT-REP-1997},{item_id:TIT-REP-1997},{item_id:QE2-REP-1969}]", requestBody["items"])
         assertEquals("ORD-1312343", requestBody["order_id"])
         assertEquals("12.99", requestBody["revenue"])
@@ -476,7 +476,7 @@ class ConstructorIoTrackingTest {
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val requestBody = getRequestBody(request)
-        val path = "/v2/behavioral_action/purchase?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        val path = "/v2/behavioral_action/purchase?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.5&_dt="
         assertEquals("[{item_id:TIT-REP-1997,variation_id:RED},{item_id:QE2-REP-1969}]", requestBody["items"])
         assertEquals("ORD-1312343", requestBody["order_id"])
         assertEquals("12.99", requestBody["revenue"])
@@ -596,7 +596,7 @@ class ConstructorIoTrackingTest {
         observer.assertComplete()
         val request = mockServer.takeRequest()
         val requestBody = getRequestBody(request)
-        val path = "/v2/behavioral_action/browse_result_click?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.1&_dt="
+        val path = "/v2/behavioral_action/browse_result_click?section=Products&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.18.5&_dt="
         assertEquals("group_id", requestBody["filter_name"])
         assertEquals("Movies", requestBody["filter_value"])
         assertEquals("TIT-REP-1997", requestBody["item_id"])

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseTest.kt
@@ -17,6 +17,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ConstructorIoBrowseTest {
 
@@ -62,18 +64,21 @@ class ConstructorIoBrowseTest {
             .setBody(TestDataLoader.loadAsString("browse_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getBrowseResults("group_id", "Beverages").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.size == 24
-            it.get()!!.response?.results!![0].value == "Crystal Geyser Natural Alpine Spring Water - 1 Gallon"
-            it.get()!!.response?.results!![0].data.id == "108200440"
-            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-108200440.png"
-            it.get()!!.response?.results!![0].data.metadata?.get("price") == 1.25
-            it.get()!!.response?.facets!!.size == 3
-            it.get()!!.response?.facets!![0].displayName == "Brand"
-            it.get()!!.response?.facets!![0].type == "multiple"
-            it.get()!!.response?.groups!!.size == 1
-            it.get()!!.response?.resultCount == 367
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertEquals(browseResponse?.response?.results?.size, 5)
+        assertEquals(browseResponse?.response?.results!![0].value, "Crystal Geyser Natural Alpine Spring Water - 1 Gallon")
+        assertEquals(browseResponse?.response?.results!![0].data.id, "108200440")
+        assertEquals(browseResponse?.response?.results!![0].data.imageUrl, "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-108200440.png")
+        assertEquals(browseResponse?.response?.results!![0].data.metadata?.get("price"), 1.25)
+        assertEquals(browseResponse?.response?.facets!!.size, 3)
+        assertEquals(browseResponse?.response?.facets!![0].displayName, "Brand")
+        assertEquals(browseResponse?.response?.facets!![0].type, "multiple")
+        assertEquals(browseResponse?.response?.groups!!.size, 1)
+        assertEquals(browseResponse?.response?.resultCount, 367)
+
         val request = mockServer.takeRequest()
         val path =
             "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.18.5&_dt"
@@ -116,12 +121,15 @@ class ConstructorIoBrowseTest {
             .setBody(TestDataLoader.loadAsString("browse_response_empty.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getBrowseResults("group_id", "Beverages").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.isEmpty()
-            it.get()!!.response?.facets!!.isEmpty()
-            it.get()!!.response?.groups!!.isEmpty()
-            it.get()!!.response?.resultCount == 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val browseResponse = observer.values()[0].get()
+        assertTrue(browseResponse?.response?.results!!.isEmpty())
+        assertTrue(browseResponse?.response?.facets!!.isEmpty())
+        assertTrue(browseResponse?.response?.groups!!.isEmpty())
+        assertTrue(browseResponse?.response?.resultCount == 0)
+
         val request = mockServer.takeRequest()
         val path =
             "/browse/group_id/Beverages?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.18.5&_dt"

--- a/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSearchTest.kt
@@ -17,6 +17,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ConstructorIoSearchTest {
 
@@ -62,19 +64,22 @@ class ConstructorIoSearchTest {
             .setBody(TestDataLoader.loadAsString("search_response.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("corn").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.size == 24
-            it.get()!!.response?.results!![0].value == "Del Monte Fresh Cut Corn Whole Kernel Golden Sweet with Natural Sea Salt - 15.25 Oz"
-            it.get()!!.response?.results!![0].data.id == "121150086"
-            it.get()!!.response?.results!![0].data.imageUrl == "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-121150086.png"
-            it.get()!!.response?.results!![0].data.metadata?.get("price") == 2.29
-            it.get()!!.response?.results!![0].matchedTerms!![0] == "corn"
-            it.get()!!.response?.facets!!.size == 3
-            it.get()!!.response?.facets!![0].displayName == "Brand"
-            it.get()!!.response?.facets!![0].type == "multiple"
-            it.get()!!.response?.groups!!.size == 1
-            it.get()!!.response?.resultCount == 225
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertEquals(searchResponse?.response?.results?.size, 24)
+        assertEquals(searchResponse?.response?.results!![0].value, "Del Monte Fresh Cut Corn Whole Kernel Golden Sweet with Natural Sea Salt - 15.25 Oz")
+        assertEquals(searchResponse?.response?.results!![0].data.id, "121150086")
+        assertEquals(searchResponse?.response?.results!![0].data.imageUrl, "https://d17bbgoo3npfov.cloudfront.net/images/farmstand-121150086.png")
+        assertEquals(searchResponse?.response?.results!![0].data.metadata?.get("price"), 2.29)
+        assertEquals(searchResponse?.response?.results!![0].matchedTerms!![0], "corn")
+        assertEquals(searchResponse?.response?.facets!!.size, 3)
+        assertEquals(searchResponse?.response?.facets!![0].displayName, "Brand")
+        assertEquals(searchResponse?.response?.facets!![0].type, "multiple")
+        assertEquals(searchResponse?.response?.groups!!.size, 1)
+        assertEquals(searchResponse?.response?.resultCount, 225)
+
         val request = mockServer.takeRequest()
         val path =
             "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.18.5&_dt="
@@ -117,12 +122,15 @@ class ConstructorIoSearchTest {
             .setBody(TestDataLoader.loadAsString("search_response_empty.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("corn").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.results!!.isEmpty()
-            it.get()!!.response?.facets!!.isEmpty()
-            it.get()!!.response?.groups!!.isEmpty()
-            it.get()!!.response?.resultCount == 0
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertTrue(searchResponse?.response?.results!!.isEmpty())
+        assertTrue(searchResponse?.response?.results!!.isEmpty())
+        assertTrue(searchResponse?.response?.results!!.isEmpty())
+        assertEquals(searchResponse?.response?.resultCount, 0)
+
         val request = mockServer.takeRequest()
         val path =
             "/search/corn?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.18.5&_dt="
@@ -135,10 +143,13 @@ class ConstructorIoSearchTest {
             .setBody(TestDataLoader.loadAsString("search_response_redirect.json"))
         mockServer.enqueue(mockResponse)
         val observer = constructorIo.getSearchResults("bbq").test()
-        observer.assertComplete().assertValue {
-            it.get()!!.response?.redirect?.data?.url == "/mccormicks_farmstand.html?barbeque-and-grilling=1"
-            it.get()!!.response?.redirect?.matchedTerms!![0] == "bbq"
-        }
+        observer.assertComplete()
+        observer.assertNoErrors()
+
+        val searchResponse = observer.values()[0].get()
+        assertEquals(searchResponse?.response?.redirect?.data?.url, "/mccormicks_farmstand.html?barbeque-and-grilling=1")
+        assertEquals(searchResponse?.response?.redirect?.matchedTerms!![0], "bbq")
+
         val request = mockServer.takeRequest()
         val path =
             "/search/bbq?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.18.5&_dt="


### PR DESCRIPTION
### Updates:
* Fix issue with tests where only the last assertion was accounted for
* The recommendation pods in the bodega index were removed for some reason 🤔 Had to re-create pdp3 pod
    * Pointed some tests to `pdp3` instead of `pdp5` so we only need 1 pod
* Fix failing tests (All tests pass)