### PR TITLE
[CSL-2281] Get rid of duplicate ef parameter

### DIFF
--- a/library/src/main/java/io/constructor/data/memory/ConfigMemoryHolder.kt
+++ b/library/src/main/java/io/constructor/data/memory/ConfigMemoryHolder.kt
@@ -18,7 +18,7 @@ class ConfigMemoryHolder @Inject constructor() {
             if (s.isNotEmpty()) {
                 s.split(";").forEach {
                     val pair = it.split("=")
-                    result.add("ef-${pair[0].base64Decode()}" to pair[1].base64Decode())
+                    result.add("${pair[0].base64Decode()}" to pair[1].base64Decode())
                 }
             }
             return result

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationQuizTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationQuizTest.kt
@@ -32,7 +32,7 @@ class ConstructorIoIntegrationQuizTest {
     fun setup() {
         every { ctx.applicationContext } returns ctx
 
-        every { preferencesHelper.apiKey } returns "ZqXaOfXuBWD4s3XzCI1q"
+        every { preferencesHelper.apiKey } returns "key_vM4GkLckwiuxwyRA"
         every { preferencesHelper.id } returns "wacko-the-guid"
         every { preferencesHelper.scheme } returns "https"
         every { preferencesHelper.serviceUrl } returns "ac.cnstrc.com"
@@ -216,14 +216,14 @@ class ConstructorIoIntegrationQuizTest {
         )
         val request = QuizRequest.Builder("test-quiz")
             .setAnswers(answers)
-            .setQuizVersionId("dd10eea4-f765-4bb1-b8e5-46b09a190cfe")
+            .setQuizVersionId("e03210db-0cc6-459c-8f17-bf014c4f554d")
             .setQuizSessionId("bc48a85d-2f45-4c91-ba3a-dcf655b33831")
             .build()
         val observer = constructorIo.getQuizResults(request).test()
 
         val quizResult = observer.values()[0].get()
         assertEquals("test-quiz", quizResult?.quizId);
-        assertEquals("dd10eea4-f765-4bb1-b8e5-46b09a190cfe", quizResult?.quizVersionId);
+        assertEquals("e03210db-0cc6-459c-8f17-bf014c4f554d", quizResult?.quizVersionId);
         assertEquals("bc48a85d-2f45-4c91-ba3a-dcf655b33831", quizResult?.quizSessionId);
 
         Thread.sleep(timeBetweenTests)
@@ -281,14 +281,14 @@ class ConstructorIoIntegrationQuizTest {
                 listOf("1"),
                 listOf("1", "2"),
                 listOf("seen")
-            )
+            )h
             val quizResult = constructorIo.getQuizResultsCRT("test-quiz",
                 answers,
-                "dd10eea4-f765-4bb1-b8e5-46b09a190cfe",
+                "e03210db-0cc6-459c-8f17-bf014c4f554d",
                 "bc48a85d-2f45-4c91-ba3a-dcf655b33831"
             )
             assertEquals("test-quiz", quizResult?.quizId);
-            assertEquals("dd10eea4-f765-4bb1-b8e5-46b09a190cfe", quizResult?.quizVersionId);
+            assertEquals("e03210db-0cc6-459c-8f17-bf014c4f554d", quizResult?.quizVersionId);
             assertEquals("bc48a85d-2f45-4c91-ba3a-dcf655b33831", quizResult?.quizSessionId);
         }
         Thread.sleep(timeBetweenTests)

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseFacetOptionsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseFacetOptionsTest.kt
@@ -77,7 +77,7 @@ class ConstructorioBrowseFacetOptionsTest {
 
         val request = mockServer.takeRequest()
         val path =
-                "/browse/facet_options?facet_name=brands&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/facet_options?facet_name=brands&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 
@@ -131,7 +131,7 @@ class ConstructorioBrowseFacetOptionsTest {
 
         val request = mockServer.takeRequest()
         val path =
-                "/browse/facet_options?fmt_options%5Bshow_hidden_facets%5D=true&facet_name=Brands&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/facet_options?fmt_options%5Bshow_hidden_facets%5D=true&facet_name=Brands&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 
@@ -146,7 +146,7 @@ class ConstructorioBrowseFacetOptionsTest {
         val observer = constructorIo.getBrowseFacetOptions(browseFacetOptionsRequest).test()
         val request = mockServer.takeRequest()
         val path =
-                "/browse/facet_options?fmt_options%5Bshow_hidden_facets%5D=true&facet_name=Brands&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/facet_options?fmt_options%5Bshow_hidden_facets%5D=true&facet_name=Brands&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseFacetsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseFacetsTest.kt
@@ -74,7 +74,7 @@ class ConstructorioBrowseFacetsTest {
 
         val request = mockServer.takeRequest()
         val path =
-                "/browse/facets?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/facets?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 
@@ -129,7 +129,7 @@ class ConstructorioBrowseFacetsTest {
 
         val request = mockServer.takeRequest()
         val path =
-                "/browse/facets?page=5&offset=10&num_results_per_page=20&fmt_options%5Bshow_hidden_facets%5D=true&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/facets?page=5&offset=10&num_results_per_page=20&fmt_options%5Bshow_hidden_facets%5D=true&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 
@@ -147,7 +147,7 @@ class ConstructorioBrowseFacetsTest {
         val observer = constructorIo.getBrowseFacets(browseFacetsRequest).test()
         val request = mockServer.takeRequest()
         val path =
-                "/browse/facets?page=5&offset=10&num_results_per_page=20&fmt_options%5Bshow_hidden_facets%5D=true&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/facets?page=5&offset=10&num_results_per_page=20&fmt_options%5Bshow_hidden_facets%5D=true&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/core/ConstructorioBrowseGroupsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioBrowseGroupsTest.kt
@@ -71,7 +71,7 @@ class ConstructorioBrowseGroupsTest {
 
         val request = mockServer.takeRequest()
         val path =
-                "/browse/groups?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/groups?key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 
@@ -125,7 +125,7 @@ class ConstructorioBrowseGroupsTest {
 
         val request = mockServer.takeRequest()
         val path =
-               "/browse/groups?filters%5Bgroup_id%5D=Brand&fmt_options%5Bgroups_max_depth%5D=1&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+               "/browse/groups?filters%5Bgroup_id%5D=Brand&fmt_options%5Bgroups_max_depth%5D=1&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 
@@ -141,7 +141,7 @@ class ConstructorioBrowseGroupsTest {
         val observer = constructorIo.getBrowseGroups(browseGroupsRequest).test()
         val request = mockServer.takeRequest()
         val path =
-                "/browse/groups?filters%5Bgroup_id%5D=Brand&fmt_options%5Bgroups_max_depth%5D=1&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.20.0"
+                "/browse/groups?filters%5Bgroup_id%5D=Brand&fmt_options%5Bgroups_max_depth%5D=1&key=silver-key&i=guapo-the-guid&ui=player-two&s=92&c=cioand-2.22.0"
         assert(request.path!!.startsWith(path))
     }
 }

--- a/library/src/test/java/io/constructor/data/memory/ConfigMemoryHolderTest.kt
+++ b/library/src/test/java/io/constructor/data/memory/ConfigMemoryHolderTest.kt
@@ -21,8 +21,8 @@ class ConfigMemoryHolderTest {
     fun verifyTestCellsWrittenAndEncoded() {
         configMemoryHolder.testCellParams = listOf("1" to "2", "3" to "4")
         val params = configMemoryHolder.testCellParams
-        assert(params[0]!!.first == "ef-1" && params[0]!!.second == "2")
-        assert(params[1]!!.first == "ef-3" && params[1]!!.second == "4")
+        assert(params[0]!!.first == "1" && params[0]!!.second == "2")
+        assert(params[1]!!.first == "3" && params[1]!!.second == "4")
     }
 
     @Test


### PR DESCRIPTION
The ef prefix was being added in both configMemoryholder.kt and requestInterceptor.kt, resulting in duplicate ef in request urls. 

This removes the code adding ef in the configMemoryHolder.kt