### PR TITLE
Fix escaping in Regex match for filter_by in variations map

### DIFF
--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -200,7 +200,7 @@ object ConstructorIo {
 
             var variationsMapJSONString = jsonAdapter.toJson(variationsMap).replace("groupBy", Constants.QueryConstants.GROUP_BY)
             if (filterBy !== null) {
-                variationsMapJSONString = variationsMapJSONString.replace(Regex("}$"), ",\"${Constants.QueryConstants.FILTER_BY}\":$filterBy}")
+                variationsMapJSONString = variationsMapJSONString.replace(Regex("\\}$"), ",\"${Constants.QueryConstants.FILTER_BY}\":$filterBy}")
             }
 
             encodedParams.add(Constants.QueryConstants.VARIATIONS_MAP.urlEncode() to variationsMapJSONString.urlEncode())


### PR DESCRIPTION
### Updates:
* Fix an issue with our Regex where the closing curly brace wasn't being escaped properly.