### PR TITLE
[CSL-3033] add client id and session id setter

### DIFF
--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -127,9 +127,23 @@ object ConstructorIo {
     fun getSessionId() = preferenceHelper.getSessionId()
 
     /**
+     *  Sets the sessionId
+     */
+    fun setSessionId(sessionId: Int) {
+        preferenceHelper.setSessionId(sessionId);
+    }
+
+    /**
      * Returns the current client identifier (a random GUID assigned to the app running on the device)
      */
     fun getClientId() = preferenceHelper.id
+
+    /**
+     *  Sets the clientId
+     */
+    fun setClientId(clientId: String) {
+        preferenceHelper.id = clientId;
+    }
 
     internal fun testInit(context: Context?, constructorIoConfig: ConstructorIoConfig, dataManager: DataManager, preferenceHelper: PreferencesHelper, configMemoryHolder: ConfigMemoryHolder) {
         if (context == null) {

--- a/library/src/main/java/io/constructor/data/local/PreferencesHelper.kt
+++ b/library/src/main/java/io/constructor/data/local/PreferencesHelper.kt
@@ -62,6 +62,10 @@ constructor(@ConstructorSdk val preferences: SharedPreferences) {
         return preferences.getInt(SESSION_ID, 1)
     }
 
+    fun setSessionId(sessionId: Int) {
+        preferences.edit().putInt(SESSION_ID, sessionId).apply()
+    }
+
     internal fun resetSession(sessionIncrementAction: ((String) -> Unit)?): Int {
         val sessionId = 1
         preferences.edit().putInt(SESSION_ID, sessionId).apply()

--- a/library/src/test/java/io/constructor/data/local/PreferencesHelperTest.kt
+++ b/library/src/test/java/io/constructor/data/local/PreferencesHelperTest.kt
@@ -58,6 +58,12 @@ class PreferencesHelperTest {
     }
 
     @Test
+    fun saveAndRetrieveSessionId() {
+        preferencesHelper.setSessionId(123);
+        assertEquals(123, preferencesHelper.getSessionId())
+    }
+
+    @Test
     fun getSessionIdAfter30Minutes() {
         preferencesHelper.resetSession(null)
         val currentTime = System.currentTimeMillis()


### PR DESCRIPTION
Tested this in a test app as well.

<img width="447" alt="Screenshot 2023-11-29 at 11 45 38 AM" src="https://github.com/Constructor-io/constructorio-client-android/assets/57369888/621efb97-afa9-45c9-901a-f84614177402">
