### PR TITLE
Fix issue with num_results query param

### DIFF
--- a/library/src/main/java/io/constructor/core/Constants.kt
+++ b/library/src/main/java/io/constructor/core/Constants.kt
@@ -50,7 +50,7 @@ class Constants {
         const val FILTER_VALUE = "filter_value"
         const val RESULT_POSITION_ON_PAGE = "result_position_on_page"
         const val RESULT_COUNT = "result_count"
-        const val NUM_RESULT = "num_result"
+        const val NUM_RESULT = "num_results"
         const val ITEM_ID = "item_id"
         const val IDS = "ids"
         const val TERM = "term"

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -1058,13 +1058,14 @@ class ConstructorIoIntegrationTest {
     @Test
     fun getRecommendationResultsAgainstRealResponse() {
         val facet = hashMapOf("Brand" to listOf("XYZ"))
-        val observer = constructorIo.getRecommendationResults("home_page_1", facet.map { it.key to it.value }).test()
+        val observer = constructorIo.getRecommendationResults("home_page_1", facet.map { it.key to it.value }, 50).test()
         observer.assertComplete()
         observer.assertNoErrors()
 
         val recommendationResponse = observer.values()[0].get()
         assertTrue(recommendationResponse?.resultId !== null)
         assertTrue(recommendationResponse?.request!!.isNotEmpty())
+        assertTrue(recommendationResponse?.request!!.get("num_results") == 50.0)
         assertTrue(recommendationResponse?.response?.pod !== null)
         assertTrue(recommendationResponse?.response?.results !== null)
         assertTrue(recommendationResponse?.response?.resultCount!! >= 0)


### PR DESCRIPTION
### Updates:
* Fix query param for `num_results`
    * There was a small typo/bug in our constants file that was causing issues when trying to retrieve more than 10 recommendation results at a time (default is 10).
    * It was setting the query param as `num_result` which is incorrect
* Update test