### PR TITLE
[CI-3414] Add analytics_tags support

### DIFF
--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -1705,6 +1705,7 @@ object ConstructorIo {
      * @param resultPositionOnPage the position of the clicked item on the page i.e. 4
      * @param sectionName the section that the results came from, i.e. "Products"
      * @param resultID the result ID of the browse response that the selection came from
+     * @param analyticsTags Additional analytics tags to pass
      */
     fun trackBrowseResultClick(filterName: String, filterValue: String, customerId: String, resultPositionOnPage: Int, sectionName: String? = null, resultID: String? = null, analyticsTags: Map<String, String>? = null) {
         var completable = trackBrowseResultClickInternal(filterName, filterValue, customerId, null, resultPositionOnPage, sectionName, resultID, analyticsTags)

--- a/library/src/main/java/io/constructor/core/ConstructorIoConfig.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIoConfig.kt
@@ -12,6 +12,7 @@ import io.constructor.BuildConfig
  *  @property testCells Test cell name/value pairs if A/B testing
  *  @property servicePort The port to use (for testing purposes only, defaults to 443)
  *  @property serviceScheme The scheme to use (for testing purposes only, defaults to HTTPS)
+ *  @property defaultAnalyticsTags Additional analytics tags to pass. Will be merged with analytics tags passed on the request level
  */
 data class ConstructorIoConfig(
         val apiKey: String,
@@ -22,5 +23,6 @@ data class ConstructorIoConfig(
         val autocompleteResultCount: Map<String, Int> = mapOf(Constants.QueryValues.SEARCH_SUGGESTIONS to 10, Constants.QueryValues.PRODUCTS to 0),
         val defaultItemSection: String = BuildConfig.DEFAULT_ITEM_SECTION,
         val servicePort: Int = BuildConfig.SERVICE_PORT,
-        val serviceScheme: String = BuildConfig.SERVICE_SCHEME
+        val serviceScheme: String = BuildConfig.SERVICE_SCHEME,
+        val defaultAnalyticsTags: Map<String, String> = emptyMap()
 )

--- a/library/src/main/java/io/constructor/data/memory/ConfigMemoryHolder.kt
+++ b/library/src/main/java/io/constructor/data/memory/ConfigMemoryHolder.kt
@@ -40,4 +40,6 @@ class ConfigMemoryHolder @Inject constructor() {
     var autocompleteResultCount: Map<String, Int>? = null
 
     var userId: String? = null
+
+    var defaultAnalyticsTags: Map<String, String>? = null
 }

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultClickRequestBody.kt
@@ -21,6 +21,7 @@ data class BrowseResultClickRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?,

--- a/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/browse/BrowseResultLoadRequestBody.kt
@@ -21,6 +21,7 @@ data class BrowseResultLoadRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/conversion/ConversionRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/conversion/ConversionRequestBody.kt
@@ -22,6 +22,7 @@ data class ConversionRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/purchase/PurchaseRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/purchase/PurchaseRequestBody.kt
@@ -18,6 +18,7 @@ data class PurchaseRequestBody(
         @Json(name = "s") val s: Int?,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name = "key") val key: String?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/quiz/QuizConversionRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/quiz/QuizConversionRequestBody.kt
@@ -23,6 +23,7 @@ data class QuizConversionRequestBody(
     @Json(name = "key") val key: String,
     @Json(name = "ui") val ui: String?,
     @Json(name = "us") val us: List<String?>,
+    @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
     @Json(name= "beacon") val beacon: Boolean?,
     @Json(name= "section") val section: String?,
     @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/quiz/QuizResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/quiz/QuizResultClickRequestBody.kt
@@ -24,6 +24,7 @@ data class QuizResultClickRequestBody(
     @Json(name = "key") val key: String,
     @Json(name = "ui") val ui: String?,
     @Json(name = "us") val us: List<String?>,
+    @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
     @Json(name= "beacon") val beacon: Boolean?,
     @Json(name= "section") val section: String?,
     @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/quiz/QuizResultLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/quiz/QuizResultLoadRequestBody.kt
@@ -20,6 +20,7 @@ data class QuizResultLoadRequestBody(
     @Json(name = "key") val key: String,
     @Json(name = "ui") val ui: String?,
     @Json(name = "us") val us: List<String?>,
+    @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
     @Json(name= "beacon") val beacon: Boolean?,
     @Json(name= "section") val section: String?,
     @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultClickRequestBody.kt
@@ -22,6 +22,7 @@ data class RecommendationResultClickRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultViewRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/recommendations/RecommendationResultViewRequestBody.kt
@@ -19,6 +19,7 @@ data class RecommendationResultViewRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/tracking/GenericResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/GenericResultClickRequestBody.kt
@@ -19,6 +19,7 @@ data class GenericResultClickRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/main/java/io/constructor/data/model/tracking/ItemDetailLoadRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/ItemDetailLoadRequestBody.kt
@@ -20,6 +20,7 @@ data class ItemDetailLoadRequestBody(
         @Json(name = "key") val key: String,
         @Json(name = "ui") val ui: String?,
         @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
         @Json(name= "beacon") val beacon: Boolean?,
         @Json(name= "section") val section: String?,
         @Json(name= "_dt") val _dt: Long?

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationQuizTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationQuizTest.kt
@@ -43,6 +43,7 @@ class ConstructorIoIntegrationQuizTest {
 
         every { configMemoryHolder.autocompleteResultCount } returns null
         every { configMemoryHolder.userId } returns "player-three"
+        every { configMemoryHolder.defaultAnalyticsTags } returns mapOf("appVersion" to "123", "appPlatform" to "Android")
         every { configMemoryHolder.testCellParams } returns emptyList()
         every { configMemoryHolder.segments } returns emptyList()
 

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationTest.kt
@@ -43,6 +43,7 @@ class ConstructorIoIntegrationTest {
         every { preferencesHelper.getSessionId(any(), any()) } returns 67
 
         every { configMemoryHolder.autocompleteResultCount } returns null
+        every { configMemoryHolder.defaultAnalyticsTags } returns mapOf("appVersion" to "123", "appPlatform" to "Android")
         every { configMemoryHolder.userId } returns "player-three"
         every { configMemoryHolder.testCellParams } returns emptyList()
         every { configMemoryHolder.segments } returns emptyList()

--- a/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioSegmentsTest.kt
@@ -44,6 +44,7 @@ class ConstructorioSegmentsTest {
         every { preferencesHelper.getSessionId(any(), any()) } returns 14
 
         every { configMemoryHolder.autocompleteResultCount } returns null
+        every { configMemoryHolder.defaultAnalyticsTags } returns mapOf("appVersion" to "123", "appPlatform" to "Android")
         every { configMemoryHolder.userId } returns "player-two"
         every { configMemoryHolder.testCellParams } returns emptyList()
         every { configMemoryHolder.segments } returns listOf("mobile", "COUNTRY_US")

--- a/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorioTestCellTest.kt
@@ -45,6 +45,7 @@ class ConstructorioTestCellTest {
 
         every { configMemoryHolder.autocompleteResultCount } returns null
         every { configMemoryHolder.userId } returns "player-two"
+        every { configMemoryHolder.defaultAnalyticsTags } returns mapOf("appVersion" to "123", "appPlatform" to "Android")
         every { configMemoryHolder.testCellParams } returns listOf("cellone" to "vanilla", "celltwo" to "whipped-cream")
         every { configMemoryHolder.segments } returns  emptyList()
 


### PR DESCRIPTION
Adds two things.

1. defaultAnalyticsTags to the config.
2. analyticsTags param to some tracking functions.

defaultAnalyticsTags will be passed with every request if exists, will be merged with analyticsTags if exists.