### PR TITLE
Replace individual usernames with team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Define which individuals or teams that are responsible for code in a repository
 
-* @VincentGalloro @HHHindawy
+* @Constructor-io/integrations-mobile-lib-kotlin-admins


### PR DESCRIPTION
## Summary
- Replace individual GitHub usernames with `@Constructor-io/integrations-mobile-lib-kotlin-admins` team in CODEOWNERS

## Related
- [CDX-322](https://linear.app/constructor/issue/CDX-322/update-codeowners)