### PR TITLE
Update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,4 @@ updates:
     # This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.
     open-pull-requests-limit: 0
     reviewers:
-      - "crgee1" # Chris
-      - "stanlp1" # Stanley
+      - "Constructor-io/integrations-mobile-lib-kotlin-admins"


### PR DESCRIPTION
### Updates:
* Adjust dependabot reviewers to tag the mobile lib kotlin group instead of individuals