### PR TITLE
[CDX-456] Add support for total_num_results_per_section in Autocomplete response

### DIFF
--- a/library/src/main/java/io/constructor/data/model/autocomplete/AutocompleteResponse.kt
+++ b/library/src/main/java/io/constructor/data/model/autocomplete/AutocompleteResponse.kt
@@ -12,7 +12,7 @@ import java.io.Serializable
 data class AutocompleteResponse (
         @Json(name = "sections") val sections: Map<String, List<Result>>?,
         @Json(name = "result_id") val resultId: String?,
-        @Json(name= "request") val request:Map<String, Any?>?,
+        @Json(name = "request") val request: Map<String, Any?>?,
         @Json(name = "total_num_results_per_section") val totalNumResultsPerSection: Map<String, Int>?,
         var rawData: String?
 ) : Serializable

--- a/library/src/main/java/io/constructor/data/model/autocomplete/AutocompleteResponse.kt
+++ b/library/src/main/java/io/constructor/data/model/autocomplete/AutocompleteResponse.kt
@@ -13,5 +13,6 @@ data class AutocompleteResponse (
         @Json(name = "sections") val sections: Map<String, List<Result>>?,
         @Json(name = "result_id") val resultId: String?,
         @Json(name= "request") val request:Map<String, Any?>?,
+        @Json(name = "total_num_results_per_section") val totalNumResultsPerSection: Map<String, Int>?,
         var rawData: String?
 ) : Serializable

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -73,6 +73,18 @@ class ConstructorIoAutocompleteTest {
     }
 
     @Test
+    fun getAutocompleteResultsWithTotalNumResultsPerSection() {
+        val mockResponse = MockResponse().setResponseCode(200)
+            .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))
+        mockServer.enqueue(mockResponse)
+        val observer = constructorIo.getAutocompleteResults("titanic").test()
+        observer.assertComplete().assertValue {
+            val totalNumResults = it.get()!!.totalNumResultsPerSection
+            totalNumResults != null && totalNumResults["Products"] == 168 && totalNumResults["Search Suggestions"] == 32
+        }
+    }
+
+    @Test
     fun getAutocompleteResultsWithFacetFilter() {
         val mockResponse = MockResponse().setResponseCode(200)
             .setBody(TestDataLoader.loadAsString("autocomplete_response.json"))

--- a/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAutocompleteTest.kt
@@ -82,6 +82,10 @@ class ConstructorIoAutocompleteTest {
             val totalNumResults = it.get()!!.totalNumResultsPerSection
             totalNumResults != null && totalNumResults["Products"] == 168 && totalNumResults["Search Suggestions"] == 32
         }
+        val request = mockServer.takeRequest()
+        val path =
+            "/autocomplete/titanic?key=golden-key&i=guido-the-guid&ui=player-one&s=79&c=cioand-2.40.0&_dt="
+        assert(request.path!!.startsWith(path))
     }
 
     @Test

--- a/library/src/test/resources/autocomplete_response.json
+++ b/library/src/test/resources/autocomplete_response.json
@@ -1,4 +1,8 @@
 {
+  "total_num_results_per_section": {
+    "Products": 168,
+    "Search Suggestions": 32
+  },
   "sections": {
     "Products": [
       {


### PR DESCRIPTION
This pull request adds support for the `total_num_results_per_section` field in the autocomplete response, ensuring that the client can access the total number of results per section in autocomplete queries. It also introduces a corresponding test to verify this new functionality.

**Autocomplete response model updates:**

* Added a new property `totalNumResultsPerSection` (mapped from `total_num_results_per_section`) to the `AutocompleteResponse` data class to capture the total number of results per section from the API response.

**Testing enhancements:**

* Added a test case `getAutocompleteResultsWithTotalNumResultsPerSection` to verify that the new `totalNumResultsPerSection` field is correctly parsed and contains expected values for each section.
* Updated the mock API response (`autocomplete_response.json`) to include the `total_num_results_per_section` field for testing purposes.