### PR TITLE
[CDX-471] Support passing itemID in trackAutocompleteSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,9 @@ ConstructorIo.trackInputFocus("")
 // Track when the user selects an autocomplete suggestion (searchTerm, originalQuery, sectionName)
 ConstructorIo.trackAutocompleteSelect("toothpicks", "tooth", "Search Suggestions")
 
+// Track when the user selects an autocomplete suggestion with an item ID (searchTerm, originalQuery, sectionName, resultGroup, resultID, itemID)
+ConstructorIo.trackAutocompleteSelect("Fashionable Toothpicks", "tooth", "Products", itemID = "1234567-AB")
+
 // Track when the user submits a search  (searchTerm, originalQuery)
 ConstructorIo.trackSearchSubmit("toothpicks", "tooth")
 ```

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -1448,18 +1448,19 @@ object ConstructorIo {
      * @param sectionName the section the selection came from, i.e. "Search Suggestions"
      * @param resultGroup the group to search within if a user selected to search in a group, i.e. "Pumpkin in Canned Goods"
      * @param resultID the result ID of the autocomplete response that the selection came from
+     * @param itemID the item ID of the selection, i.e. "ITEM-123"
      */
-    fun trackAutocompleteSelect(searchTerm: String, originalQuery: String, sectionName: String, resultGroup: ResultGroup? = null, resultID: String? = null) {
-        var completable = trackAutocompleteSelectInternal(searchTerm, originalQuery, sectionName, resultGroup, resultID)
+    fun trackAutocompleteSelect(searchTerm: String, originalQuery: String, sectionName: String, resultGroup: ResultGroup? = null, resultID: String? = null, itemID: String? = null) {
+        var completable = trackAutocompleteSelectInternal(searchTerm, originalQuery, sectionName, resultGroup, resultID, itemID)
         disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({
             context.broadcastIntent(Constants.EVENT_QUERY_SENT, Constants.EXTRA_TERM to searchTerm)
         }, {
             t -> e("Autocomplete Select error: ${t.message}")
         }))
     }
-    internal fun trackAutocompleteSelectInternal(searchTerm: String, originalQuery: String, sectionName: String, resultGroup: ResultGroup? = null, resultID: String? = null): Completable {
+    internal fun trackAutocompleteSelectInternal(searchTerm: String, originalQuery: String, sectionName: String, resultGroup: ResultGroup? = null, resultID: String? = null, itemID: String? = null): Completable {
         preferenceHelper.getSessionId(sessionIncrementHandler)
-        val encodedParams: ArrayList<Pair<String, String>> = getEncodedParams(groupId = resultGroup?.groupId, groupDisplayName = resultGroup?.displayName, resultId = resultID)
+        val encodedParams: ArrayList<Pair<String, String>> = getEncodedParams(groupId = resultGroup?.groupId, groupDisplayName = resultGroup?.displayName, resultId = resultID, itemId = itemID)
 
         return dataManager.trackAutocompleteSelect(searchTerm, arrayOf(
             Constants.QueryConstants.SECTION to sectionName,

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -300,6 +300,17 @@ class ConstructorIoTrackingTest {
     }
 
     @Test
+    fun trackAutocompleteSelectWithItemID() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+        val observer = ConstructorIo.trackAutocompleteSelectInternal("titanic", "tit", "Search Suggestions", null, null, "TIT-REP-1997").test()
+        observer.assertComplete()
+        val request = mockServer.takeRequest()
+        val path = "/autocomplete/titanic/select?section=Search%20Suggestions&original_query=tit&tr=click&item_id=TIT-REP-1997&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.41.0&_dt="
+        assert(request.path!!.startsWith(path))
+    }
+
+    @Test
     fun trackAutocompleteSelectWithServerError() {
         val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
         mockServer.enqueue(mockResponse)

--- a/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoTrackingTest.kt
@@ -303,10 +303,10 @@ class ConstructorIoTrackingTest {
     fun trackAutocompleteSelectWithItemID() {
         val mockResponse = MockResponse().setResponseCode(204)
         mockServer.enqueue(mockResponse)
-        val observer = ConstructorIo.trackAutocompleteSelectInternal("titanic", "tit", "Search Suggestions", null, null, "TIT-REP-1997").test()
+        val observer = ConstructorIo.trackAutocompleteSelectInternal("titanic", "tit", "Products", null, null, "TIT-REP-1997").test()
         observer.assertComplete()
         val request = mockServer.takeRequest()
-        val path = "/autocomplete/titanic/select?section=Search%20Suggestions&original_query=tit&tr=click&item_id=TIT-REP-1997&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.41.0&_dt="
+        val path = "/autocomplete/titanic/select?section=Products&original_query=tit&tr=click&item_id=TIT-REP-1997&key=copper-key&i=wacko-the-guid&ui=player-three&s=67&c=cioand-2.41.0&_dt="
         assert(request.path!!.startsWith(path))
     }
 


### PR DESCRIPTION
Support passing an `itemID` parameter to the existing `trackAutocompleteSelect` function.

1 test added ✅ 