### PR TITLE
[CDX-475] Implement ASA tracking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Three types of these events exist:
 4. **Recommendation Events** measure user interaction with recommendation results
 5. **Quiz Events** measure user interaction with quiz results
 6. **Conversion Events** measure user events like `add to cart` or `purchase`
+7. **Agent Events** measure user interaction with the AI agent search assistant
 
 ### Autocomplete Events
 
@@ -670,5 +671,49 @@ val items = listOf(
 ConstructorIo.trackResultsImpressionView(
     items = items,
     searchTerm = "sneakers"
+)
+```
+
+### Agent Search Assistant (ASA) Events
+
+```kotlin
+// Track when a user submits an intent to the agent (intent, sectionName?)
+ConstructorIo.trackAgentSubmit("find me a red shirt")
+
+// Track when agent results start loading (intent, sectionName?, intentResultId?)
+ConstructorIo.trackAgentResultLoadStarted("find me a red shirt", intentResultId = "intent-123")
+
+// Track when agent results finish loading (intent, searchResultCount, sectionName?, intentResultId?)
+ConstructorIo.trackAgentResultLoadFinished("find me a red shirt", 25, intentResultId = "intent-123")
+
+// Track when an agent search result is clicked (intent, searchResultId, itemId?, itemName?, variationId?, sectionName?, intentResultId?)
+ConstructorIo.trackAgentResultClick(
+    intent = "find me a red shirt",
+    searchResultId = "result-123",
+    itemId = "item-456",
+    itemName = "Red Shirt",
+    variationId = "var-789",
+    intentResultId = "intent-123"
+)
+
+// Track when agent search results are viewed (intent, searchResultId, numResultsViewed, items?, sectionName?, intentResultId?)
+val items = listOf(
+    ResultsImpressionItem("item-1", "Item One"),
+    ResultsImpressionItem("item-2", "Item Two", variationId = "var-2")
+)
+ConstructorIo.trackAgentResultView(
+    intent = "find me a red shirt",
+    searchResultId = "result-123",
+    numResultsViewed = 5,
+    items = items,
+    intentResultId = "intent-123"
+)
+
+// Track when a user submits a search from within the agent (intent, searchTerm, searchResultId, sectionName?, intentResultId?)
+ConstructorIo.trackAgentSearchSubmit(
+    intent = "find me a red shirt",
+    searchTerm = "red shirt",
+    searchResultId = "result-123",
+    intentResultId = "intent-123"
 )
 ```

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -23,10 +23,7 @@ import io.constructor.data.model.recommendations.RecommendationResultClickReques
 import io.constructor.data.model.recommendations.RecommendationResultViewRequestBody
 import io.constructor.data.model.recommendations.RecommendationsResponse
 import io.constructor.data.model.search.*
-import io.constructor.data.model.tracking.GenericResultClickRequestBody
-import io.constructor.data.model.tracking.ItemDetailLoadRequestBody
-import io.constructor.data.model.tracking.MediaImpressionRequestBody
-import io.constructor.data.model.tracking.ResultsImpressionViewRequestBody
+import io.constructor.data.model.tracking.*
 import io.constructor.injection.component.AppComponent
 import io.constructor.injection.component.DaggerAppComponent
 import io.constructor.injection.module.AppModule
@@ -2371,5 +2368,270 @@ object ConstructorIo {
                 recommendationResultViewRequestBody,
                 arrayOf(Constants.QueryConstants.SECTION to section)
         )
+    }
+
+    /**
+     * Tracks agent submit events.
+     *
+     * Example:
+     * ```
+     * ConstructorIo.trackAgentSubmit("find me a red shirt")
+     * ```
+     * @param intent the user's intent/query submitted to the agent
+     * @param sectionName the section name (defaults to "Products")
+     * @param analyticsTags additional analytics tags to pass
+     */
+    fun trackAgentSubmit(intent: String, sectionName: String? = null, analyticsTags: Map<String, String>? = null) {
+        val completable = trackAgentSubmitInternal(intent, sectionName, analyticsTags)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Agent Submit error: ${t.message}")
+        }))
+    }
+
+    internal fun trackAgentSubmitInternal(intent: String, sectionName: String? = null, analyticsTags: Map<String, String>? = null): Completable {
+        preferenceHelper.getSessionId(sessionIncrementHandler)
+        val section = sectionName ?: preferenceHelper.defaultItemSection
+        val requestBody = AgentSubmitRequestBody(
+                intent,
+                true,
+                section,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
+                configMemoryHolder.userId,
+                configMemoryHolder.segments,
+                mergeAnalyticsTags(configMemoryHolder.defaultAnalyticsTags, analyticsTags),
+                System.currentTimeMillis()
+        )
+
+        return dataManager.trackAgentSubmit(requestBody)
+    }
+
+    /**
+     * Tracks agent result load started events.
+     *
+     * Example:
+     * ```
+     * ConstructorIo.trackAgentResultLoadStarted("find me a red shirt")
+     * ```
+     * @param intent the user's intent/query submitted to the agent
+     * @param sectionName the section name (defaults to "Products")
+     * @param intentResultId the intent result identifier
+     * @param analyticsTags additional analytics tags to pass
+     */
+    fun trackAgentResultLoadStarted(intent: String, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null) {
+        val completable = trackAgentResultLoadStartedInternal(intent, sectionName, intentResultId, analyticsTags)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Agent Result Load Started error: ${t.message}")
+        }))
+    }
+
+    internal fun trackAgentResultLoadStartedInternal(intent: String, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null): Completable {
+        preferenceHelper.getSessionId(sessionIncrementHandler)
+        val section = sectionName ?: preferenceHelper.defaultItemSection
+        val requestBody = AgentResultLoadStartedRequestBody(
+                intent,
+                true,
+                section,
+                intentResultId,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
+                configMemoryHolder.userId,
+                configMemoryHolder.segments,
+                mergeAnalyticsTags(configMemoryHolder.defaultAnalyticsTags, analyticsTags),
+                System.currentTimeMillis()
+        )
+
+        return dataManager.trackAgentResultLoadStarted(requestBody)
+    }
+
+    /**
+     * Tracks agent result load finished events.
+     *
+     * Example:
+     * ```
+     * ConstructorIo.trackAgentResultLoadFinished("find me a red shirt", 25)
+     * ```
+     * @param intent the user's intent/query submitted to the agent
+     * @param searchResultCount the number of search results returned
+     * @param sectionName the section name (defaults to "Products")
+     * @param intentResultId the intent result identifier
+     * @param analyticsTags additional analytics tags to pass
+     */
+    fun trackAgentResultLoadFinished(intent: String, searchResultCount: Int, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null) {
+        val completable = trackAgentResultLoadFinishedInternal(intent, searchResultCount, sectionName, intentResultId, analyticsTags)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Agent Result Load Finished error: ${t.message}")
+        }))
+    }
+
+    internal fun trackAgentResultLoadFinishedInternal(intent: String, searchResultCount: Int, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null): Completable {
+        preferenceHelper.getSessionId(sessionIncrementHandler)
+        val section = sectionName ?: preferenceHelper.defaultItemSection
+        val requestBody = AgentResultLoadFinishedRequestBody(
+                intent,
+                searchResultCount,
+                true,
+                section,
+                intentResultId,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
+                configMemoryHolder.userId,
+                configMemoryHolder.segments,
+                mergeAnalyticsTags(configMemoryHolder.defaultAnalyticsTags, analyticsTags),
+                System.currentTimeMillis()
+        )
+
+        return dataManager.trackAgentResultLoadFinished(requestBody)
+    }
+
+    /**
+     * Tracks agent result click events.
+     *
+     * Example:
+     * ```
+     * ConstructorIo.trackAgentResultClick("find me a red shirt", "result-123")
+     * ```
+     * @param intent the user's intent/query submitted to the agent
+     * @param searchResultId the identifier of the search result clicked
+     * @param itemId the item identifier
+     * @param itemName the item name
+     * @param variationId the variation identifier
+     * @param sectionName the section name (defaults to "Products")
+     * @param intentResultId the intent result identifier
+     * @param analyticsTags additional analytics tags to pass
+     */
+    fun trackAgentResultClick(intent: String, searchResultId: String, itemId: String? = null, itemName: String? = null, variationId: String? = null, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null) {
+        val completable = trackAgentResultClickInternal(intent, searchResultId, itemId, itemName, variationId, sectionName, intentResultId, analyticsTags)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Agent Result Click error: ${t.message}")
+        }))
+    }
+
+    internal fun trackAgentResultClickInternal(intent: String, searchResultId: String, itemId: String? = null, itemName: String? = null, variationId: String? = null, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null): Completable {
+        preferenceHelper.getSessionId(sessionIncrementHandler)
+        val section = sectionName ?: preferenceHelper.defaultItemSection
+        val requestBody = AgentResultClickRequestBody(
+                intent,
+                searchResultId,
+                itemId,
+                itemName,
+                variationId,
+                true,
+                section,
+                intentResultId,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
+                configMemoryHolder.userId,
+                configMemoryHolder.segments,
+                mergeAnalyticsTags(configMemoryHolder.defaultAnalyticsTags, analyticsTags),
+                System.currentTimeMillis()
+        )
+
+        return dataManager.trackAgentResultClick(
+                requestBody,
+                arrayOf(Constants.QueryConstants.SECTION to section)
+        )
+    }
+
+    /**
+     * Tracks agent result view events.
+     *
+     * Example:
+     * ```
+     * ConstructorIo.trackAgentResultView("find me a red shirt", "result-123", 5)
+     * ```
+     * @param intent the user's intent/query submitted to the agent
+     * @param searchResultId the identifier of the search result
+     * @param numResultsViewed the number of results viewed
+     * @param items the list of items viewed (capped at 100)
+     * @param sectionName the section name (defaults to "Products")
+     * @param intentResultId the intent result identifier
+     * @param analyticsTags additional analytics tags to pass
+     */
+    fun trackAgentResultView(intent: String, searchResultId: String, numResultsViewed: Int, items: List<ResultsImpressionItem>? = null, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null) {
+        val completable = trackAgentResultViewInternal(intent, searchResultId, numResultsViewed, items, sectionName, intentResultId, analyticsTags)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Agent Result View error: ${t.message}")
+        }))
+    }
+
+    internal fun trackAgentResultViewInternal(intent: String, searchResultId: String, numResultsViewed: Int, items: List<ResultsImpressionItem>? = null, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null): Completable {
+        preferenceHelper.getSessionId(sessionIncrementHandler)
+        val section = sectionName ?: preferenceHelper.defaultItemSection
+        val cappedItems = items?.take(100)
+        val requestBody = AgentResultViewRequestBody(
+                intent,
+                searchResultId,
+                numResultsViewed,
+                cappedItems,
+                true,
+                section,
+                intentResultId,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
+                configMemoryHolder.userId,
+                configMemoryHolder.segments,
+                mergeAnalyticsTags(configMemoryHolder.defaultAnalyticsTags, analyticsTags),
+                System.currentTimeMillis()
+        )
+
+        return dataManager.trackAgentResultView(
+                requestBody,
+                arrayOf(Constants.QueryConstants.SECTION to section)
+        )
+    }
+
+    /**
+     * Tracks agent search submit events.
+     *
+     * Example:
+     * ```
+     * ConstructorIo.trackAgentSearchSubmit("find me a red shirt", "red shirt", "result-123")
+     * ```
+     * @param intent the user's intent/query submitted to the agent
+     * @param searchTerm the search term submitted
+     * @param searchResultId the identifier of the search result
+     * @param sectionName the section name (defaults to "Products")
+     * @param intentResultId the intent result identifier
+     * @param analyticsTags additional analytics tags to pass
+     */
+    fun trackAgentSearchSubmit(intent: String, searchTerm: String, searchResultId: String, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null) {
+        val completable = trackAgentSearchSubmitInternal(intent, searchTerm, searchResultId, sectionName, intentResultId, analyticsTags)
+        disposable.add(completable.subscribeOn(Schedulers.io()).subscribe({}, {
+            t -> e("Agent Search Submit error: ${t.message}")
+        }))
+    }
+
+    internal fun trackAgentSearchSubmitInternal(intent: String, searchTerm: String, searchResultId: String, sectionName: String? = null, intentResultId: String? = null, analyticsTags: Map<String, String>? = null): Completable {
+        preferenceHelper.getSessionId(sessionIncrementHandler)
+        val section = sectionName ?: preferenceHelper.defaultItemSection
+        val requestBody = AgentSearchSubmitRequestBody(
+                intent,
+                searchTerm,
+                searchResultId,
+                true,
+                section,
+                intentResultId,
+                BuildConfig.CLIENT_VERSION,
+                preferenceHelper.id,
+                preferenceHelper.getSessionId(),
+                preferenceHelper.apiKey,
+                configMemoryHolder.userId,
+                configMemoryHolder.segments,
+                mergeAnalyticsTags(configMemoryHolder.defaultAnalyticsTags, analyticsTags),
+                System.currentTimeMillis()
+        )
+
+        return dataManager.trackAgentSearchSubmit(requestBody)
     }
 }

--- a/library/src/main/java/io/constructor/core/ConstructorIo.kt
+++ b/library/src/main/java/io/constructor/core/ConstructorIo.kt
@@ -2535,10 +2535,7 @@ object ConstructorIo {
                 System.currentTimeMillis()
         )
 
-        return dataManager.trackAgentResultClick(
-                requestBody,
-                arrayOf(Constants.QueryConstants.SECTION to section)
-        )
+        return dataManager.trackAgentResultClick(requestBody)
     }
 
     /**
@@ -2585,10 +2582,7 @@ object ConstructorIo {
                 System.currentTimeMillis()
         )
 
-        return dataManager.trackAgentResultView(
-                requestBody,
-                arrayOf(Constants.QueryConstants.SECTION to section)
-        )
+        return dataManager.trackAgentResultView(requestBody)
     }
 
     /**

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Moshi
 import io.constructor.data.local.PreferencesHelper
 import io.constructor.data.model.autocomplete.AutocompleteResponse
 import io.constructor.data.model.browse.*
-import io.constructor.data.model.tracking.ItemDetailLoadRequestBody
+import io.constructor.data.model.tracking.*
 import io.constructor.data.model.conversion.ConversionRequestBody
 import io.constructor.data.model.purchase.PurchaseRequestBody
 import io.constructor.data.model.quiz.*
@@ -12,9 +12,6 @@ import io.constructor.data.model.recommendations.RecommendationResultClickReques
 import io.constructor.data.model.recommendations.RecommendationResultViewRequestBody
 import io.constructor.data.model.recommendations.RecommendationsResponse
 import io.constructor.data.model.search.*
-import io.constructor.data.model.tracking.GenericResultClickRequestBody
-import io.constructor.data.model.tracking.MediaImpressionRequestBody
-import io.constructor.data.model.tracking.ResultsImpressionViewRequestBody
 import io.constructor.data.remote.ApiPaths
 import io.constructor.data.remote.ConstructorApi
 import io.constructor.injection.ConstructorSdk
@@ -317,6 +314,30 @@ constructor(private val constructorApi: ConstructorApi, @ConstructorSdk private 
 
     fun trackResultsImpressionView(resultsImpressionViewRequestBody: ResultsImpressionViewRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
         return constructorApi.trackResultsImpressionView(resultsImpressionViewRequestBody, params.toMap())
+    }
+
+    fun trackAgentSubmit(body: AgentSubmitRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
+        return constructorApi.trackAgentSubmit(body, params.toMap())
+    }
+
+    fun trackAgentResultLoadStarted(body: AgentResultLoadStartedRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
+        return constructorApi.trackAgentResultLoadStarted(body, params.toMap())
+    }
+
+    fun trackAgentResultLoadFinished(body: AgentResultLoadFinishedRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
+        return constructorApi.trackAgentResultLoadFinished(body, params.toMap())
+    }
+
+    fun trackAgentResultClick(body: AgentResultClickRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
+        return constructorApi.trackAgentResultClick(body, params.toMap())
+    }
+
+    fun trackAgentResultView(body: AgentResultViewRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
+        return constructorApi.trackAgentResultView(body, params.toMap())
+    }
+
+    fun trackAgentSearchSubmit(body: AgentSearchSubmitRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
+        return constructorApi.trackAgentSearchSubmit(body, params.toMap())
     }
 
     fun trackMediaImpressionView(preferencesHelper: PreferencesHelper, mediaImpressionRequestBody: MediaImpressionRequestBody): Completable {

--- a/library/src/main/java/io/constructor/data/DataManager.kt
+++ b/library/src/main/java/io/constructor/data/DataManager.kt
@@ -328,12 +328,12 @@ constructor(private val constructorApi: ConstructorApi, @ConstructorSdk private 
         return constructorApi.trackAgentResultLoadFinished(body, params.toMap())
     }
 
-    fun trackAgentResultClick(body: AgentResultClickRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
-        return constructorApi.trackAgentResultClick(body, params.toMap())
+    fun trackAgentResultClick(body: AgentResultClickRequestBody): Completable {
+        return constructorApi.trackAgentResultClick(body)
     }
 
-    fun trackAgentResultView(body: AgentResultViewRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {
-        return constructorApi.trackAgentResultView(body, params.toMap())
+    fun trackAgentResultView(body: AgentResultViewRequestBody): Completable {
+        return constructorApi.trackAgentResultView(body)
     }
 
     fun trackAgentSearchSubmit(body: AgentSearchSubmitRequestBody, params: Array<Pair<String, String>> = arrayOf()): Completable {

--- a/library/src/main/java/io/constructor/data/model/tracking/AgentResultClickRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/AgentResultClickRequestBody.kt
@@ -1,0 +1,25 @@
+package io.constructor.data.model.tracking
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class AgentResultClickRequestBody(
+        @Json(name = "intent") val intent: String,
+        @Json(name = "search_result_id") val searchResultId: String,
+        @Json(name = "item_id") val itemId: String?,
+        @Json(name = "item_name") val itemName: String?,
+        @Json(name = "variation_id") val variationId: String?,
+        @Json(name = "beacon") val beacon: Boolean = true,
+        @Json(name = "section") val section: String?,
+        @Json(name = "intent_result_id") val intentResultId: String?,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
+        @Json(name = "_dt") val _dt: Long?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/model/tracking/AgentResultLoadFinishedRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/AgentResultLoadFinishedRequestBody.kt
@@ -1,0 +1,22 @@
+package io.constructor.data.model.tracking
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class AgentResultLoadFinishedRequestBody(
+        @Json(name = "intent") val intent: String,
+        @Json(name = "search_result_count") val searchResultCount: Int,
+        @Json(name = "beacon") val beacon: Boolean = true,
+        @Json(name = "section") val section: String?,
+        @Json(name = "intent_result_id") val intentResultId: String?,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
+        @Json(name = "_dt") val _dt: Long?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/model/tracking/AgentResultLoadStartedRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/AgentResultLoadStartedRequestBody.kt
@@ -1,0 +1,21 @@
+package io.constructor.data.model.tracking
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class AgentResultLoadStartedRequestBody(
+        @Json(name = "intent") val intent: String,
+        @Json(name = "beacon") val beacon: Boolean = true,
+        @Json(name = "section") val section: String?,
+        @Json(name = "intent_result_id") val intentResultId: String?,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
+        @Json(name = "_dt") val _dt: Long?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/model/tracking/AgentResultViewRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/AgentResultViewRequestBody.kt
@@ -1,0 +1,25 @@
+package io.constructor.data.model.tracking
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import io.constructor.data.model.common.ResultsImpressionItem
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class AgentResultViewRequestBody(
+        @Json(name = "intent") val intent: String,
+        @Json(name = "search_result_id") val searchResultId: String,
+        @Json(name = "num_results_viewed") val numResultsViewed: Int,
+        @Json(name = "items") val items: List<ResultsImpressionItem>?,
+        @Json(name = "beacon") val beacon: Boolean = true,
+        @Json(name = "section") val section: String?,
+        @Json(name = "intent_result_id") val intentResultId: String?,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
+        @Json(name = "_dt") val _dt: Long?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/model/tracking/AgentSearchSubmitRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/AgentSearchSubmitRequestBody.kt
@@ -1,0 +1,23 @@
+package io.constructor.data.model.tracking
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class AgentSearchSubmitRequestBody(
+        @Json(name = "intent") val intent: String,
+        @Json(name = "search_term") val searchTerm: String,
+        @Json(name = "search_result_id") val searchResultId: String,
+        @Json(name = "beacon") val beacon: Boolean = true,
+        @Json(name = "section") val section: String?,
+        @Json(name = "intent_result_id") val intentResultId: String?,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
+        @Json(name = "_dt") val _dt: Long?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/model/tracking/AgentSubmitRequestBody.kt
+++ b/library/src/main/java/io/constructor/data/model/tracking/AgentSubmitRequestBody.kt
@@ -1,0 +1,20 @@
+package io.constructor.data.model.tracking
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.io.Serializable
+
+@JsonClass(generateAdapter = true)
+data class AgentSubmitRequestBody(
+        @Json(name = "intent") val intent: String,
+        @Json(name = "beacon") val beacon: Boolean = true,
+        @Json(name = "section") val section: String?,
+        @Json(name = "c") val c: String,
+        @Json(name = "i") val i: String,
+        @Json(name = "s") val s: Int,
+        @Json(name = "key") val key: String,
+        @Json(name = "ui") val ui: String?,
+        @Json(name = "us") val us: List<String?>,
+        @Json(name = "analytics_tags") val analyticsTags: Map<String, String>?,
+        @Json(name = "_dt") val _dt: Long?
+) : Serializable

--- a/library/src/main/java/io/constructor/data/remote/ApiPaths.kt
+++ b/library/src/main/java/io/constructor/data/remote/ApiPaths.kt
@@ -38,4 +38,10 @@ object ApiPaths {
     const val URL_MEDIA_IMPRESSION_VIEW_EVENT = "v2/ad_behavioral_action/display_ad_view"
     const val URL_MEDIA_IMPRESSION_CLICK_EVENT = "v2/ad_behavioral_action/display_ad_click"
     const val URL_RESULTS_IMPRESSION_VIEW_EVENT = "v2/behavioral_action/impression_view"
+    const val URL_AGENT_SUBMIT_EVENT = "v2/behavioral_action/assistant_submit"
+    const val URL_AGENT_RESULT_LOAD_STARTED_EVENT = "v2/behavioral_action/assistant_result_load_start"
+    const val URL_AGENT_RESULT_LOAD_FINISHED_EVENT = "v2/behavioral_action/assistant_result_load_finish"
+    const val URL_AGENT_RESULT_CLICK_EVENT = "v2/behavioral_action/assistant_search_result_click"
+    const val URL_AGENT_RESULT_VIEW_EVENT = "v2/behavioral_action/assistant_search_result_view"
+    const val URL_AGENT_SEARCH_SUBMIT_EVENT = "v2/behavioral_action/assistant_search_submit"
 }

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -2,10 +2,7 @@ package io.constructor.data.remote
 
 import io.constructor.data.model.autocomplete.AutocompleteResponse
 import io.constructor.data.model.browse.*
-import io.constructor.data.model.tracking.GenericResultClickRequestBody
-import io.constructor.data.model.tracking.ItemDetailLoadRequestBody
-import io.constructor.data.model.tracking.MediaImpressionRequestBody
-import io.constructor.data.model.tracking.ResultsImpressionViewRequestBody
+import io.constructor.data.model.tracking.*
 import io.constructor.data.model.conversion.ConversionRequestBody
 import io.constructor.data.model.purchase.PurchaseRequestBody
 import io.constructor.data.model.quiz.*
@@ -147,6 +144,24 @@ interface ConstructorApi {
 
     @POST(ApiPaths.URL_RESULTS_IMPRESSION_VIEW_EVENT)
     fun trackResultsImpressionView(@Body body: ResultsImpressionViewRequestBody, @QueryMap params: Map<String, String>): Completable
+
+    @POST(ApiPaths.URL_AGENT_SUBMIT_EVENT)
+    fun trackAgentSubmit(@Body body: AgentSubmitRequestBody, @QueryMap params: Map<String, String>): Completable
+
+    @POST(ApiPaths.URL_AGENT_RESULT_LOAD_STARTED_EVENT)
+    fun trackAgentResultLoadStarted(@Body body: AgentResultLoadStartedRequestBody, @QueryMap params: Map<String, String>): Completable
+
+    @POST(ApiPaths.URL_AGENT_RESULT_LOAD_FINISHED_EVENT)
+    fun trackAgentResultLoadFinished(@Body body: AgentResultLoadFinishedRequestBody, @QueryMap params: Map<String, String>): Completable
+
+    @POST(ApiPaths.URL_AGENT_RESULT_CLICK_EVENT)
+    fun trackAgentResultClick(@Body body: AgentResultClickRequestBody, @QueryMap params: Map<String, String>): Completable
+
+    @POST(ApiPaths.URL_AGENT_RESULT_VIEW_EVENT)
+    fun trackAgentResultView(@Body body: AgentResultViewRequestBody, @QueryMap params: Map<String, String>): Completable
+
+    @POST(ApiPaths.URL_AGENT_SEARCH_SUBMIT_EVENT)
+    fun trackAgentSearchSubmit(@Body body: AgentSearchSubmitRequestBody, @QueryMap params: Map<String, String>): Completable
 
     @GET
     fun getQuizNextQuestion(@Url quizUrl: String): Single<Result<ResponseBody>>

--- a/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
+++ b/library/src/main/java/io/constructor/data/remote/ConstructorApi.kt
@@ -155,10 +155,10 @@ interface ConstructorApi {
     fun trackAgentResultLoadFinished(@Body body: AgentResultLoadFinishedRequestBody, @QueryMap params: Map<String, String>): Completable
 
     @POST(ApiPaths.URL_AGENT_RESULT_CLICK_EVENT)
-    fun trackAgentResultClick(@Body body: AgentResultClickRequestBody, @QueryMap params: Map<String, String>): Completable
+    fun trackAgentResultClick(@Body body: AgentResultClickRequestBody): Completable
 
     @POST(ApiPaths.URL_AGENT_RESULT_VIEW_EVENT)
-    fun trackAgentResultView(@Body body: AgentResultViewRequestBody, @QueryMap params: Map<String, String>): Completable
+    fun trackAgentResultView(@Body body: AgentResultViewRequestBody): Completable
 
     @POST(ApiPaths.URL_AGENT_SEARCH_SUBMIT_EVENT)
     fun trackAgentSearchSubmit(@Body body: AgentSearchSubmitRequestBody, @QueryMap params: Map<String, String>): Completable

--- a/library/src/test/java/io/constructor/core/ConstructorIoAgentTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAgentTrackingTest.kt
@@ -262,7 +262,6 @@ class ConstructorIoAgentTrackingTest {
 
         val requestBody = getRequestBody(request)
         assertEquals("Search Suggestions", requestBody["section"])
-        assert(request.path!!.contains("section=Search+Suggestions") || request.path!!.contains("section=Search%20Suggestions"))
     }
 
     @Test

--- a/library/src/test/java/io/constructor/core/ConstructorIoAgentTrackingTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoAgentTrackingTest.kt
@@ -1,0 +1,466 @@
+package io.constructor.core
+
+import android.content.Context
+import io.constructor.data.local.PreferencesHelper
+import io.constructor.data.memory.ConfigMemoryHolder
+import io.constructor.data.model.common.ResultsImpressionItem
+import io.constructor.test.createTestDataManager
+import io.constructor.util.RxSchedulersOverrideRule
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.net.SocketTimeoutException
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+class ConstructorIoAgentTrackingTest {
+
+    @Rule
+    @JvmField
+    val overrideSchedulersRule = RxSchedulersOverrideRule()
+
+    private lateinit var mockServer: MockWebServer
+    private var constructorIo = ConstructorIo
+    private val ctx = mockk<Context>()
+    private val preferencesHelper = mockk<PreferencesHelper>()
+    private val configMemoryHolder = mockk<ConfigMemoryHolder>()
+
+    @Before
+    fun setup() {
+        mockServer = MockWebServer()
+        mockServer.start()
+
+        every { ctx.applicationContext } returns ctx
+
+        every { preferencesHelper.apiKey } returns "copper-key"
+        every { preferencesHelper.id } returns "wacko-the-guid"
+        every { preferencesHelper.serviceUrl } returns mockServer.hostName
+        every { preferencesHelper.port } returns mockServer.port
+        every { preferencesHelper.scheme } returns "http"
+        every { preferencesHelper.defaultItemSection } returns "Products"
+        every { preferencesHelper.getSessionId(any(), any()) } returns 67
+
+        every { configMemoryHolder.autocompleteResultCount } returns null
+        every { configMemoryHolder.defaultAnalyticsTags } returns mapOf("appVersion" to "123", "appPlatform" to "Android")
+        every { configMemoryHolder.userId } returns "player-three"
+        every { configMemoryHolder.testCellParams } returns emptyList()
+        every { configMemoryHolder.segments } returns emptyList()
+
+        val config = ConstructorIoConfig("dummyKey")
+        val dataManager = createTestDataManager(preferencesHelper, configMemoryHolder)
+
+        constructorIo.testInit(ctx, config, dataManager, preferencesHelper, configMemoryHolder)
+    }
+
+    @After
+    fun tearDown() {
+        mockServer.shutdown()
+    }
+
+    // --- trackAgentSubmit ---
+
+    @Test
+    fun trackAgentSubmit() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSubmitInternal("find me a red shirt").test()
+        observer.assertComplete()
+        val request = awaitRequest()
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_submit"))
+
+        val requestBody = getRequestBody(request)
+        assertEquals("find me a red shirt", requestBody["intent"])
+        assertEquals("true", requestBody["beacon"])
+        assertEquals("Products", requestBody["section"])
+        assertEquals("wacko-the-guid", requestBody["i"])
+        assertEquals("67", requestBody["s"])
+    }
+
+    @Test
+    fun trackAgentSubmitWithSection() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSubmitInternal("find me a red shirt", sectionName = "Search Suggestions").test()
+        observer.assertComplete()
+        val request = awaitRequest()
+
+        val requestBody = getRequestBody(request)
+        assertEquals("Search Suggestions", requestBody["section"])
+    }
+
+    @Test
+    fun trackAgentSubmit500() {
+        val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSubmitInternal("find me a red shirt").test()
+        observer.assertError { true }
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_submit"))
+    }
+
+    @Test
+    fun trackAgentSubmitTimeout() {
+        val mockResponse = MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal server error")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSubmitInternal("find me a red shirt").test()
+        observer.awaitDone(6, TimeUnit.SECONDS)
+        observer.assertError(SocketTimeoutException::class.java)
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_submit"))
+    }
+
+    // --- trackAgentResultLoadStarted ---
+
+    @Test
+    fun trackAgentResultLoadStarted() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultLoadStartedInternal("find me a red shirt", intentResultId = "intent-123").test()
+        observer.assertComplete()
+        val request = awaitRequest()
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_result_load_start"))
+
+        val requestBody = getRequestBody(request)
+        assertEquals("find me a red shirt", requestBody["intent"])
+        assertEquals("intent-123", requestBody["intent_result_id"])
+        assertEquals("true", requestBody["beacon"])
+        assertEquals("Products", requestBody["section"])
+    }
+
+    @Test
+    fun trackAgentResultLoadStarted500() {
+        val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultLoadStartedInternal("find me a red shirt").test()
+        observer.assertError { true }
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_result_load_start"))
+    }
+
+    @Test
+    fun trackAgentResultLoadStartedTimeout() {
+        val mockResponse = MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal server error")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultLoadStartedInternal("find me a red shirt").test()
+        observer.awaitDone(6, TimeUnit.SECONDS)
+        observer.assertError(SocketTimeoutException::class.java)
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_result_load_start"))
+    }
+
+    // --- trackAgentResultLoadFinished ---
+
+    @Test
+    fun trackAgentResultLoadFinished() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultLoadFinishedInternal("find me a red shirt", 25, intentResultId = "intent-123").test()
+        observer.assertComplete()
+        val request = awaitRequest()
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_result_load_finish"))
+
+        val requestBody = getRequestBody(request)
+        assertEquals("find me a red shirt", requestBody["intent"])
+        assertEquals("25", requestBody["search_result_count"])
+        assertEquals("intent-123", requestBody["intent_result_id"])
+        assertEquals("true", requestBody["beacon"])
+        assertEquals("Products", requestBody["section"])
+    }
+
+    @Test
+    fun trackAgentResultLoadFinished500() {
+        val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultLoadFinishedInternal("find me a red shirt", 25).test()
+        observer.assertError { true }
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_result_load_finish"))
+    }
+
+    @Test
+    fun trackAgentResultLoadFinishedTimeout() {
+        val mockResponse = MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal server error")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultLoadFinishedInternal("find me a red shirt", 25).test()
+        observer.awaitDone(6, TimeUnit.SECONDS)
+        observer.assertError(SocketTimeoutException::class.java)
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_result_load_finish"))
+    }
+
+    // --- trackAgentResultClick ---
+
+    @Test
+    fun trackAgentResultClick() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultClickInternal(
+                "find me a red shirt",
+                "result-123",
+                itemId = "item-456",
+                itemName = "Red Shirt",
+                variationId = "var-789",
+                intentResultId = "intent-123"
+        ).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_result_click"))
+
+        val requestBody = getRequestBody(request)
+        assertEquals("find me a red shirt", requestBody["intent"])
+        assertEquals("result-123", requestBody["search_result_id"])
+        assertEquals("item-456", requestBody["item_id"])
+        assertEquals("Red Shirt", requestBody["item_name"])
+        assertEquals("var-789", requestBody["variation_id"])
+        assertEquals("intent-123", requestBody["intent_result_id"])
+        assertEquals("true", requestBody["beacon"])
+        assertEquals("Products", requestBody["section"])
+    }
+
+    @Test
+    fun trackAgentResultClickWithSection() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultClickInternal(
+                "find me a red shirt",
+                "result-123",
+                sectionName = "Search Suggestions"
+        ).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+
+        val requestBody = getRequestBody(request)
+        assertEquals("Search Suggestions", requestBody["section"])
+        assert(request.path!!.contains("section=Search+Suggestions") || request.path!!.contains("section=Search%20Suggestions"))
+    }
+
+    @Test
+    fun trackAgentResultClick500() {
+        val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultClickInternal("find me a red shirt", "result-123").test()
+        observer.assertError { true }
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_result_click"))
+    }
+
+    @Test
+    fun trackAgentResultClickTimeout() {
+        val mockResponse = MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal server error")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultClickInternal("find me a red shirt", "result-123").test()
+        observer.awaitDone(6, TimeUnit.SECONDS)
+        observer.assertError(SocketTimeoutException::class.java)
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_result_click"))
+    }
+
+    // --- trackAgentResultView ---
+
+    @Test
+    fun trackAgentResultView() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val items = listOf(
+                ResultsImpressionItem("item-1", "Item One"),
+                ResultsImpressionItem("item-2", "Item Two", variationId = "var-2")
+        )
+        val observer = ConstructorIo.trackAgentResultViewInternal(
+                "find me a red shirt",
+                "result-123",
+                5,
+                items,
+                intentResultId = "intent-123"
+        ).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_result_view"))
+
+        val requestBody = getRequestBody(request)
+        assertEquals("find me a red shirt", requestBody["intent"])
+        assertEquals("result-123", requestBody["search_result_id"])
+        assertEquals("5", requestBody["num_results_viewed"])
+        assertEquals("intent-123", requestBody["intent_result_id"])
+        assertEquals("true", requestBody["beacon"])
+        assertEquals("Products", requestBody["section"])
+        assert(requestBody["items"]!!.contains("item_id:item-1"))
+        assert(requestBody["items"]!!.contains("item_name:Item One"))
+        assert(requestBody["items"]!!.contains("item_id:item-2"))
+        assert(requestBody["items"]!!.contains("variation_id:var-2"))
+    }
+
+    @Test
+    fun trackAgentResultViewCapsItemsAt100() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val items = (1..150).map { ResultsImpressionItem("item-$it", "Item $it") }
+        val observer = ConstructorIo.trackAgentResultViewInternal(
+                "find me a red shirt",
+                "result-123",
+                150,
+                items
+        ).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+
+        val requestBody = getRequestBody(request)
+        assert(requestBody["items"]!!.contains("item_id:item-100"))
+        assert(!requestBody["items"]!!.contains("item_id:item-101"))
+    }
+
+    @Test
+    fun trackAgentResultView500() {
+        val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultViewInternal("find me a red shirt", "result-123", 5).test()
+        observer.assertError { true }
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_result_view"))
+    }
+
+    @Test
+    fun trackAgentResultViewTimeout() {
+        val mockResponse = MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal server error")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentResultViewInternal("find me a red shirt", "result-123", 5).test()
+        observer.awaitDone(6, TimeUnit.SECONDS)
+        observer.assertError(SocketTimeoutException::class.java)
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_result_view"))
+    }
+
+    // --- trackAgentSearchSubmit ---
+
+    @Test
+    fun trackAgentSearchSubmit() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSearchSubmitInternal(
+                "find me a red shirt",
+                "red shirt",
+                "result-123",
+                intentResultId = "intent-123"
+        ).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+        assertEquals("POST", request.method)
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_submit"))
+
+        val requestBody = getRequestBody(request)
+        assertEquals("find me a red shirt", requestBody["intent"])
+        assertEquals("red shirt", requestBody["search_term"])
+        assertEquals("result-123", requestBody["search_result_id"])
+        assertEquals("intent-123", requestBody["intent_result_id"])
+        assertEquals("true", requestBody["beacon"])
+        assertEquals("Products", requestBody["section"])
+    }
+
+    @Test
+    fun trackAgentSearchSubmitWithSection() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSearchSubmitInternal(
+                "find me a red shirt",
+                "red shirt",
+                "result-123",
+                sectionName = "Search Suggestions"
+        ).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+
+        val requestBody = getRequestBody(request)
+        assertEquals("Search Suggestions", requestBody["section"])
+    }
+
+    @Test
+    fun trackAgentSearchSubmit500() {
+        val mockResponse = MockResponse().setResponseCode(500).setBody("Internal server error")
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSearchSubmitInternal("find me a red shirt", "red shirt", "result-123").test()
+        observer.assertError { true }
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_submit"))
+    }
+
+    @Test
+    fun trackAgentSearchSubmitTimeout() {
+        val mockResponse = MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal server error")
+                .setBodyDelay(5, TimeUnit.SECONDS)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSearchSubmitInternal("find me a red shirt", "red shirt", "result-123").test()
+        observer.awaitDone(6, TimeUnit.SECONDS)
+        observer.assertError(SocketTimeoutException::class.java)
+        val request = awaitRequest()
+        assert(request.path!!.startsWith("/v2/behavioral_action/assistant_search_submit"))
+    }
+
+    // --- Analytics tags ---
+
+    @Test
+    fun trackAgentSubmitWithAnalyticsTags() {
+        val mockResponse = MockResponse().setResponseCode(204)
+        mockServer.enqueue(mockResponse)
+
+        val observer = ConstructorIo.trackAgentSubmitInternal("find me a red shirt", analyticsTags = mapOf("test" to "test1", "appVersion" to "150")).test()
+        observer.assertComplete()
+        val request = awaitRequest()
+
+        val requestBody = getRequestBody(request)
+        assertEquals("{appVersion:150,appPlatform:Android,test:test1}", requestBody["analytics_tags"])
+    }
+
+    private fun awaitRequest(): RecordedRequest {
+        return mockServer.takeRequest(1, TimeUnit.SECONDS)
+                ?: throw AssertionError("Expected request but timed out")
+    }
+}

--- a/library/src/test/java/io/constructor/core/ConstructorIoIntegrationQuizTest.kt
+++ b/library/src/test/java/io/constructor/core/ConstructorIoIntegrationQuizTest.kt
@@ -27,6 +27,8 @@ class ConstructorIoIntegrationQuizTest {
     private val preferencesHelper = mockk<PreferencesHelper>()
     private val configMemoryHolder = mockk<ConfigMemoryHolder>()
     private val timeBetweenTests = 2000.toLong()
+    private val quizVersionId = "cc8a9dac-d337-4dbc-bbf7-48469c0de7af"
+    private val quizSessionId = "session-id"
 
     @Before
     fun setup() {
@@ -98,6 +100,8 @@ class ConstructorIoIntegrationQuizTest {
         val answers = listOf(listOf("1"))
         val request = QuizRequest.Builder("test-quiz")
             .setAnswers(answers)
+            .setQuizVersionId(quizVersionId)
+            .setQuizSessionId(quizSessionId)
             .build()
         val observer = constructorIo.getQuizNextQuestion(request).test()
         observer.assertComplete()
@@ -131,6 +135,8 @@ class ConstructorIoIntegrationQuizTest {
         )
         val request = QuizRequest.Builder("test-quiz")
                 .setAnswers(answers)
+                .setQuizVersionId(quizVersionId)
+                .setQuizSessionId(quizSessionId)
                 .build()
         val observer = constructorIo.getQuizNextQuestion(request).test()
         observer.assertComplete()
@@ -158,6 +164,8 @@ class ConstructorIoIntegrationQuizTest {
         )
         val request = QuizRequest.Builder("test-quiz")
                 .setAnswers(answers)
+                .setQuizVersionId(quizVersionId)
+                .setQuizSessionId(quizSessionId)
                 .build()
         val observer = constructorIo.getQuizNextQuestion(request).test()
         observer.assertComplete()
@@ -187,6 +195,8 @@ class ConstructorIoIntegrationQuizTest {
         )
         val request = QuizRequest.Builder("test-quiz")
                 .setAnswers(answers)
+                .setQuizVersionId(quizVersionId)
+                .setQuizSessionId(quizSessionId)
                 .build()
         val observer = constructorIo.getQuizNextQuestion(request).test()
         observer.assertComplete()
@@ -205,10 +215,13 @@ class ConstructorIoIntegrationQuizTest {
         val answers = listOf(
             listOf("1"),
             listOf("1", "2"),
-            listOf("seen")
+            listOf("seen"),
+            listOf("true")
         )
         val request = QuizRequest.Builder("test-quiz")
             .setAnswers(answers)
+            .setQuizVersionId(quizVersionId)
+            .setQuizSessionId(quizSessionId)
             .build()
         val observer = constructorIo.getQuizResults(request).test()
 
@@ -232,10 +245,12 @@ class ConstructorIoIntegrationQuizTest {
         val answers = listOf(
             listOf("1"),
             listOf("1", "2"),
-            listOf("seen")
+            listOf("seen"),
+            listOf("true")
         )
         val request = QuizRequest.Builder("test-quiz")
             .setAnswers(answers)
+            .setQuizVersionId(quizVersionId)
             .setQuizSessionId("bc48a85d-2f45-4c91-ba3a-dcf655b33831")
             .build()
         val observer = constructorIo.getQuizResults(request).test()
@@ -255,7 +270,7 @@ class ConstructorIoIntegrationQuizTest {
                 listOf("1", "2"),
                 listOf("seen")
             )
-            val quizResult = constructorIo.getQuizNextQuestionCRT("test-quiz", answers)
+            val quizResult = constructorIo.getQuizNextQuestionCRT("test-quiz", answers, quizVersionId, quizSessionId)
             assertNotNull(quizResult?.quizId)
             assertNotNull(quizResult?.quizVersionId)
             assertNotNull(quizResult?.quizSessionId)
@@ -276,9 +291,10 @@ class ConstructorIoIntegrationQuizTest {
             val answers = listOf(
                 listOf("1"),
                 listOf("1", "2"),
-                listOf("seen")
+                listOf("seen"),
+                listOf("true")
             )
-            val quizResult = constructorIo.getQuizResultsCRT("test-quiz", answers)
+            val quizResult = constructorIo.getQuizResultsCRT("test-quiz", answers, quizVersionId, quizSessionId)
             assertEquals(quizResult?.quizId, "test-quiz");
             assertNotNull(quizResult?.quizVersionId)
             assertNotNull(quizResult?.quizSessionId)
@@ -299,11 +315,12 @@ class ConstructorIoIntegrationQuizTest {
             val answers = listOf(
                 listOf("1"),
                 listOf("1", "2"),
-                listOf("seen")
+                listOf("seen"),
+                listOf("true")
             )
             val quizResult = constructorIo.getQuizResultsCRT("test-quiz",
                 answers,
-                null,
+                quizVersionId,
                 "bc48a85d-2f45-4c91-ba3a-dcf655b33831"
             )
             assertEquals("test-quiz", quizResult?.quizId);


### PR DESCRIPTION
## Summary
This implementation mirrors the swift one: https://github.com/Constructor-io/constructorio-client-swift/pull/278

- Add 6 Agent Search Assistant (ASA) tracking events: `trackAgentSubmit`, `trackAgentResultLoadStarted`, `trackAgentResultLoadFinished`, `trackAgentResultClick`, `trackAgentResultView`, `trackAgentSearchSubmit`
- Add request body models, API paths, Retrofit endpoints, DataManager pass-throughs, and public fire-and-forget methods
- Add unit tests covering success, error, timeout, optional params, analytics tags, and 100-item cap
- Fix quiz integration tests to pass `quiz_session_id` with answers per updated API requirement
- Add README documentation for ASA events

## Test plan
- [ ] Run `ConstructorIoAgentTrackingTest` (23 tests covering all 6 events)
- [ ] Run `ConstructorIoIntegrationQuizTest` to verify quiz test fix
- [ ] Verify tracking calls hit correct `/v2/behavioral_action/` endpoints

Note: There are some request/response mismatches due to searchability issues. I've opened a thread to investigate it.