### PR TITLE
[CDX-494] Keep Moshi core runtime classes to fix R8 full-mode JSON crash

### DIFF
--- a/library/consumer-rules.pro
+++ b/library/consumer-rules.pro
@@ -2,6 +2,17 @@
 # These rules are bundled with the AAR and applied automatically to consuming apps
 
 ####--------Moshi---------####
+# Keep annotation/generic-signature metadata that Moshi reads reflectively at runtime.
+-keepattributes *Annotation*, Signature, EnclosingMethod, InnerClasses
+
+# Keep Moshi's core runtime classes. R8 (especially full mode) can rename or
+# horizontally merge JsonReader/JsonAdapter, which breaks the identity check
+# Moshi's AdapterMethodsFactory performs on @FromJson/@ToJson parameter types
+# (crash: "Unexpected signature ... fromJson(ya.m, ya.h, ya.h)").
+-keep class com.squareup.moshi.** { *; }
+-keep interface com.squareup.moshi.** { *; }
+-dontwarn com.squareup.moshi.**
+
 # Keep Moshi annotations so @FromJson/@ToJson reflective adapter discovery works
 -keepclassmembers class * {
     @com.squareup.moshi.FromJson <methods>;

--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -11,6 +11,15 @@
 -dontwarn okio.**
 -dontwarn javax.annotation.Nullable
 -dontwarn javax.annotation.ParametersAreNonnullByDefault
+-keepattributes *Annotation*, Signature, EnclosingMethod, InnerClasses
+
+# Keep Moshi's core runtime classes. R8 (especially full mode) can rename or
+# horizontally merge JsonReader/JsonAdapter, which breaks the identity check
+# Moshi's AdapterMethodsFactory performs on @FromJson/@ToJson parameter types.
+-keep class com.squareup.moshi.** { *; }
+-keep interface com.squareup.moshi.** { *; }
+-dontwarn com.squareup.moshi.**
+
 -keepclasseswithmembers class * {
     @com.squareup.moshi.* <methods>;
 }


### PR DESCRIPTION
**Summary**

- Add `-keep` rules for `com.squareup.moshi.**` core runtime classes/interfaces to `library/consumer-rules.pro` and `library/proguard-rules.pro`.
- Add `-keepattributes *Annotation*, Signature, EnclosingMethod, InnerClasses` so Moshi's reflective adapter discovery keeps working under obfuscation.
- Add `-dontwarn com.squareup.moshi.**`.

**Why?**

R8 (especially full mode) can rename or horizontally merge `JsonReader`/`JsonAdapter`. This breaks the identity check `AdapterMethodsFactory` runs on `@FromJson`/`@ToJson` parameter types, crashing release builds with `Unexpected signature ... fromJson(ya.m, ya.h, ya.h)`. The prior rules only kept Moshi annotations and annotated members, not the runtime classes themselves.

- `consumer-rules.pro` — ships inside the AAR and applies to the consuming app's R8 build. This protects Moshi when someone else's app uses our library.
- `proguard-rules.pro` — applies when this library itself is built/minified (and in the library's own tests/benchmarks). This protects Moshi when our own code is run through R8.